### PR TITLE
feat(certificados): módulo completo — auto-emisión + panel admin + descarga PDF (B0-B4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,10 +76,16 @@ CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
 FROM python-base as production
 
 # Install runtime dependencies
+# weasyprint deps: pango, cairo, gdk-pixbuf, shared-mime-info
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
     libcairo2 \
+    libcairo-gobject2 \
     libglib2.0-0 \
+    libpango-1.0-0 \
+    libpangoft2-1.0-0 \
+    libgdk-pixbuf-2.0-0 \
+    shared-mime-info \
     gettext \
     curl \
     && rm -rf /var/lib/apt/lists/*

--- a/apps/certifications/apps.py
+++ b/apps/certifications/apps.py
@@ -5,3 +5,7 @@ class CertificationsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.certifications"
     verbose_name = "Certificaciones"
+
+    def ready(self):
+        # Connect signals (B1 will populate signals.py)
+        from . import signals  # noqa: F401

--- a/apps/certifications/forms.py
+++ b/apps/certifications/forms.py
@@ -1,6 +1,70 @@
 """
-Forms for certifications app.
+Forms for certifications app — staff-side panel to manage CertificateTemplate.
 
-B2 sub-feature populates this with CertificateTemplateForm for the custom
-admin panel that allows staff to edit certificate templates from the UI.
+B2 sub-feature: CertificateTemplateForm exposes all template fields so staff
+users can create / edit a CertificateTemplate from the custom UI panel
+(`/certificates/admin/templates/`).
 """
+
+from django import forms
+
+from .models import CertificateTemplate
+
+
+class CertificateTemplateForm(forms.ModelForm):
+    """Form for staff to create/edit a CertificateTemplate from the custom panel."""
+
+    class Meta:
+        model = CertificateTemplate
+        fields = [
+            "name",
+            "description",
+            "template_file",
+            "background_image",
+            "logo",
+            "signature_image",
+            "signer_name",
+            "signer_title",
+            "is_active",
+        ]
+        widgets = {
+            "name": forms.TextInput(
+                attrs={"class": "input input-bordered w-full", "required": True}
+            ),
+            "description": forms.Textarea(
+                attrs={"class": "textarea textarea-bordered w-full", "rows": 2}
+            ),
+            "template_file": forms.ClearableFileInput(
+                attrs={
+                    "class": "file-input file-input-bordered w-full",
+                    "accept": ".html",
+                }
+            ),
+            "background_image": forms.ClearableFileInput(
+                attrs={
+                    "class": "file-input file-input-bordered w-full",
+                    "accept": "image/*",
+                }
+            ),
+            "logo": forms.ClearableFileInput(
+                attrs={
+                    "class": "file-input file-input-bordered w-full",
+                    "accept": "image/*",
+                }
+            ),
+            "signature_image": forms.ClearableFileInput(
+                attrs={
+                    "class": "file-input file-input-bordered w-full",
+                    "accept": "image/*",
+                }
+            ),
+            "signer_name": forms.TextInput(
+                attrs={"class": "input input-bordered w-full"}
+            ),
+            "signer_title": forms.TextInput(
+                attrs={"class": "input input-bordered w-full"}
+            ),
+            "is_active": forms.CheckboxInput(
+                attrs={"class": "toggle toggle-primary"}
+            ),
+        }

--- a/apps/certifications/forms.py
+++ b/apps/certifications/forms.py
@@ -1,0 +1,6 @@
+"""
+Forms for certifications app.
+
+B2 sub-feature populates this with CertificateTemplateForm for the custom
+admin panel that allows staff to edit certificate templates from the UI.
+"""

--- a/apps/certifications/signals.py
+++ b/apps/certifications/signals.py
@@ -1,0 +1,6 @@
+"""
+Signals for certifications app.
+
+Currently a stub. B1 sub-feature implements the post_save signal that
+auto-issues certificates when an Enrollment status transitions to COMPLETED.
+"""

--- a/apps/certifications/signals.py
+++ b/apps/certifications/signals.py
@@ -1,6 +1,71 @@
 """
 Signals for certifications app.
 
-Currently a stub. B1 sub-feature implements the post_save signal that
-auto-issues certificates when an Enrollment status transitions to COMPLETED.
+When an Enrollment transitions to COMPLETED, automatically issue a certificate
+for the (user, course) pair if one doesn't already exist (idempotent).
 """
+
+import logging
+
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(
+    post_save,
+    sender="courses.Enrollment",
+    dispatch_uid="cert_on_enrollment_complete",
+)
+def issue_certificate_on_enrollment_completed(sender, instance, created, **kwargs):
+    """
+    Auto-issue a certificate when Enrollment.status becomes COMPLETED.
+
+    Idempotent: if a valid ISSUED certificate already exists for this
+    (user, course), does nothing. Uses transaction.on_commit so the side-effect
+    runs only if the outer transaction succeeds.
+    """
+    # Local imports avoid AppRegistryNotReady on Django startup
+    from apps.certifications.models import Certificate
+    from apps.certifications.services import CertificateService
+    from apps.courses.models import Enrollment
+
+    if instance.status != Enrollment.Status.COMPLETED:
+        return
+
+    # Already-issued check: if a valid ISSUED certificate exists, skip.
+    existing = Certificate.objects.filter(
+        user_id=instance.user_id,
+        course_id=instance.course_id,
+        status=Certificate.Status.ISSUED,
+    ).exists()
+    if existing:
+        return
+
+    def _issue():
+        try:
+            CertificateService.issue_certificate(
+                user=instance.user,
+                course=instance.course,
+            )
+            logger.info(
+                "Auto-issued certificate for enrollment %s (user=%s, course=%s)",
+                instance.pk,
+                instance.user_id,
+                instance.course_id,
+            )
+        except ValueError as e:
+            logger.warning(
+                "Cannot auto-issue certificate for enrollment %s: %s",
+                instance.pk,
+                e,
+            )
+        except Exception:
+            logger.exception(
+                "Unexpected error auto-issuing certificate for enrollment %s",
+                instance.pk,
+            )
+
+    transaction.on_commit(_issue)

--- a/apps/certifications/templates/certifications/admin/_template_row.html
+++ b/apps/certifications/templates/certifications/admin/_template_row.html
@@ -1,0 +1,38 @@
+{% load static %}
+<tr id="tpl-row-{{ t.pk }}">
+    <td>
+        <div class="flex flex-col">
+            <span class="font-medium text-gray-900 dark:text-white">{{ t.name }}</span>
+            {% if t.description %}
+                <span class="text-xs text-gray-500 dark:text-gray-400">{{ t.description|truncatechars:80 }}</span>
+            {% endif %}
+        </div>
+    </td>
+    <td>
+        <div class="flex flex-col">
+            <span class="text-sm">{{ t.signer_name|default:"—" }}</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">{{ t.signer_title|default:"" }}</span>
+        </div>
+    </td>
+    <td class="text-center">
+        <form hx-post="{% url 'certifications:template_toggle_active' t.pk %}"
+              hx-target="#tpl-row-{{ t.pk }}"
+              hx-swap="outerHTML">
+            {% csrf_token %}
+            <button type="submit"
+                    class="badge {% if t.is_active %}badge-success{% else %}badge-ghost{% endif %} cursor-pointer">
+                {% if t.is_active %}Activa{% else %}Inactiva{% endif %}
+            </button>
+        </form>
+    </td>
+    <td class="text-right">
+        <div class="flex justify-end gap-2">
+            <a href="{% url 'certifications:template_preview' t.pk %}"
+               target="_blank"
+               rel="noopener"
+               class="btn btn-ghost btn-xs">Preview</a>
+            <a href="{% url 'certifications:template_edit' t.pk %}"
+               class="btn btn-primary btn-xs">Editar</a>
+        </div>
+    </td>
+</tr>

--- a/apps/certifications/templates/certifications/admin/template_form.html
+++ b/apps/certifications/templates/certifications/admin/template_form.html
@@ -1,0 +1,163 @@
+{% extends "base/dashboard.html" %}
+{% block title %}
+    {% if template %}Editar plantilla{% else %}Nueva plantilla{% endif %} · SD LMS
+{% endblock %}
+{% block page_title %}
+    {% if template %}
+        Editar plantilla: {{ template.name }}
+    {% else %}
+        Nueva plantilla de certificado
+    {% endif %}
+{% endblock %}
+{% block page_description %}
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        Parametriza el formato, imágenes y firma de la plantilla. La vista previa usa datos de ejemplo.
+    </p>
+    <p class="mt-2">
+        <a href="{% url 'certifications:template_list' %}"
+           class="link link-primary text-sm">← Volver a la lista</a>
+    </p>
+{% endblock %}
+{% block dashboard_content %}
+    <form method="post" enctype="multipart/form-data" class="space-y-6">
+        {% csrf_token %}
+        {% if form.non_field_errors %}
+            <div class="alert alert-error">{{ form.non_field_errors }}</div>
+        {% endif %}
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <!-- Columna izquierda: datos básicos -->
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 space-y-4">
+                <h3 class="text-base font-semibold text-gray-900 dark:text-white border-b border-gray-200 dark:border-gray-700 pb-2">
+                    Datos básicos
+                </h3>
+                <div class="form-control">
+                    <label class="label" for="{{ form.name.id_for_label }}">
+                        <span class="label-text">Nombre <span class="text-error">*</span></span>
+                    </label>
+                    {{ form.name }}
+                    {% if form.name.errors %}<p class="text-error text-xs mt-1">{{ form.name.errors|join:", " }}</p>{% endif %}
+                </div>
+                <div class="form-control">
+                    <label class="label" for="{{ form.description.id_for_label }}">
+                        <span class="label-text">Descripción</span>
+                    </label>
+                    {{ form.description }}
+                    {% if form.description.errors %}
+                        <p class="text-error text-xs mt-1">{{ form.description.errors|join:", " }}</p>
+                    {% endif %}
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="form-control">
+                        <label class="label" for="{{ form.signer_name.id_for_label }}">
+                            <span class="label-text">Nombre del firmante</span>
+                        </label>
+                        {{ form.signer_name }}
+                        {% if form.signer_name.errors %}
+                            <p class="text-error text-xs mt-1">{{ form.signer_name.errors|join:", " }}</p>
+                        {% endif %}
+                    </div>
+                    <div class="form-control">
+                        <label class="label" for="{{ form.signer_title.id_for_label }}">
+                            <span class="label-text">Cargo del firmante</span>
+                        </label>
+                        {{ form.signer_title }}
+                        {% if form.signer_title.errors %}
+                            <p class="text-error text-xs mt-1">{{ form.signer_title.errors|join:", " }}</p>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="form-control">
+                    <label class="label cursor-pointer justify-start gap-3">
+                        {{ form.is_active }}
+                        <span class="label-text">Plantilla activa</span>
+                    </label>
+                    {% if form.is_active.errors %}
+                        <p class="text-error text-xs mt-1">{{ form.is_active.errors|join:", " }}</p>
+                    {% endif %}
+                </div>
+            </div>
+            <!-- Columna derecha: archivos e imágenes -->
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 space-y-4">
+                <h3 class="text-base font-semibold text-gray-900 dark:text-white border-b border-gray-200 dark:border-gray-700 pb-2">
+                    Archivos e imágenes
+                </h3>
+                <div class="form-control">
+                    <label class="label" for="{{ form.template_file.id_for_label }}">
+                        <span class="label-text">Archivo de plantilla (HTML)</span>
+                    </label>
+                    {{ form.template_file }}
+                    {% if template and template.template_file %}
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            Actual: <code>{{ template.template_file.name }}</code>
+                        </p>
+                    {% endif %}
+                    {% if form.template_file.errors %}
+                        <p class="text-error text-xs mt-1">{{ form.template_file.errors|join:", " }}</p>
+                    {% endif %}
+                </div>
+                <div class="form-control">
+                    <label class="label" for="{{ form.background_image.id_for_label }}">
+                        <span class="label-text">Imagen de fondo</span>
+                    </label>
+                    {{ form.background_image }}
+                    {% if template and template.background_image %}
+                        <img src="{{ template.background_image.url }}"
+                             alt="fondo"
+                             class="mt-2 h-16 rounded border border-gray-200 dark:border-gray-700">
+                    {% endif %}
+                    {% if form.background_image.errors %}
+                        <p class="text-error text-xs mt-1">{{ form.background_image.errors|join:", " }}</p>
+                    {% endif %}
+                </div>
+                <div class="form-control">
+                    <label class="label" for="{{ form.logo.id_for_label }}">
+                        <span class="label-text">Logo</span>
+                    </label>
+                    {{ form.logo }}
+                    {% if template and template.logo %}
+                        <img src="{{ template.logo.url }}"
+                             alt="logo"
+                             class="mt-2 h-16 rounded border border-gray-200 dark:border-gray-700">
+                    {% endif %}
+                    {% if form.logo.errors %}<p class="text-error text-xs mt-1">{{ form.logo.errors|join:", " }}</p>{% endif %}
+                </div>
+                <div class="form-control">
+                    <label class="label" for="{{ form.signature_image.id_for_label }}">
+                        <span class="label-text">Imagen de firma</span>
+                    </label>
+                    {{ form.signature_image }}
+                    {% if template and template.signature_image %}
+                        <img src="{{ template.signature_image.url }}"
+                             alt="firma"
+                             class="mt-2 h-16 rounded border border-gray-200 dark:border-gray-700">
+                    {% endif %}
+                    {% if form.signature_image.errors %}
+                        <p class="text-error text-xs mt-1">{{ form.signature_image.errors|join:", " }}</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        <!-- Vista previa (solo en modo edit, ya hay PK) -->
+        {% if template %}
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+                <div class="flex justify-between items-center mb-3">
+                    <h3 class="text-base font-semibold text-gray-900 dark:text-white">Vista previa</h3>
+                    <a href="{% url 'certifications:template_preview' template.pk %}"
+                       target="_blank"
+                       rel="noopener"
+                       class="btn btn-ghost btn-sm">Abrir en pestaña nueva ↗</a>
+                </div>
+                <iframe src="{% url 'certifications:template_preview' template.pk %}"
+                        class="w-full h-[480px] border border-gray-200 dark:border-gray-700 rounded bg-white"
+                        title="Vista previa de plantilla"></iframe>
+            </div>
+        {% endif %}
+        <!-- Acciones -->
+        <div class="flex justify-end gap-3">
+            <a href="{% url 'certifications:template_list' %}" class="btn btn-ghost">Cancelar</a>
+            <button type="submit" class="btn btn-primary">
+                {% if template %}Guardar cambios{% else %}Crear plantilla{% endif %}
+            </button>
+        </div>
+    </form>
+{% endblock %}

--- a/apps/certifications/templates/certifications/admin/template_list.html
+++ b/apps/certifications/templates/certifications/admin/template_list.html
@@ -1,0 +1,55 @@
+{% extends "base/dashboard.html" %}
+{% block title %}Plantillas de certificado · SD LMS{% endblock %}
+{% block page_title %}Plantillas de certificado{% endblock %}
+{% block page_description %}
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        Gestiona las plantillas usadas para emitir certificados. La plantilla activa más reciente se usa por defecto.
+    </p>
+{% endblock %}
+{% block dashboard_content %}
+    <div class="flex justify-between items-center mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+            {{ templates|length }} plantilla{{ templates|length|pluralize }}
+        </h2>
+        <a href="{% url 'certifications:template_create' %}" class="btn btn-primary btn-sm">
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 class="h-4 w-4"
+                 fill="none"
+                 viewBox="0 0 24 24"
+                 stroke="currentColor">
+                <path stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M12 4v16m8-8H4" />
+            </svg>
+            Nueva plantilla
+        </a>
+    </div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+        <div class="overflow-x-auto">
+            <table class="table table-zebra w-full">
+                <thead>
+                    <tr>
+                        <th>Nombre</th>
+                        <th>Firmante</th>
+                        <th class="text-center">Activa</th>
+                        <th class="text-right">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody id="templates-tbody">
+                    {% for t in templates %}
+                        {% include "certifications/admin/_template_row.html" with t=t %}
+                    {% empty %}
+                        <tr>
+                            <td colspan="4" class="text-center py-12 text-gray-500 dark:text-gray-400">
+                                Aún no hay plantillas creadas.
+                                <a href="{% url 'certifications:template_create' %}"
+                                   class="link link-primary">Crear la primera</a>.
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock %}

--- a/apps/certifications/templates/certifications/admin/template_preview.html
+++ b/apps/certifications/templates/certifications/admin/template_preview.html
@@ -1,0 +1,13 @@
+{# Wrapper opcional. La vista `template_preview` devuelve directamente el HTML #}
+{# generado por `CertificateTemplateService.preview_template`, así que este    #}
+{# archivo solo se usa si se decide envolver el preview en chrome de admin.    #}
+<!DOCTYPE html>
+<html lang="es">
+    <head>
+        <meta charset="UTF-8">
+        <title>Vista previa de plantilla</title>
+    </head>
+    <body>
+        {{ preview_html|safe }}
+    </body>
+</html>

--- a/apps/certifications/templates/certifications/certificate_template.html
+++ b/apps/certifications/templates/certifications/certificate_template.html
@@ -1,132 +1,204 @@
-<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html lang="es">
-    <head>
-        <meta charset="UTF-8">
-        <title>Certificado - {{ certificate.certificate_number }}</title>
-        <style>
+<head>
+    <meta charset="UTF-8">
+    <title>Certificado {{ certificate_number }}</title>
+    <style>
         @page {
-            size: landscape;
+            size: A4 landscape;
             margin: 0;
+        }
+        * {
+            box-sizing: border-box;
         }
         body {
             font-family: 'Helvetica', 'Arial', sans-serif;
             margin: 0;
-            padding: 40px;
-            background: #fff;
+            padding: 0;
+            background: #ffffff;
+            color: #222;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
         }
-        .certificate {
-            border: 8px double #1a365d;
-            padding: 40px;
-            text-align: center;
-            min-height: 500px;
+        .page {
             position: relative;
+            width: 297mm;
+            height: 210mm;
+            background: #ffffff;
+            overflow: hidden;
         }
-        .header {
-            margin-bottom: 30px;
+        /* Triangulo rojo superior izquierdo */
+        .triangle-tl {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 0;
+            height: 0;
+            border-top: 110mm solid #E50019;
+            border-right: 110mm solid transparent;
         }
-        .title {
-            font-size: 48px;
+        /* Triangulo rojo inferior derecho */
+        .triangle-br {
+            position: absolute;
+            bottom: 0;
+            right: 0;
+            width: 0;
+            height: 0;
+            border-bottom: 110mm solid #E50019;
+            border-left: 110mm solid transparent;
+        }
+        .content {
+            position: relative;
+            z-index: 2;
+            padding: 18mm 30mm;
+            text-align: center;
+            height: 100%;
+        }
+        .logo {
+            margin-bottom: 6mm;
+        }
+        .logo img {
+            max-height: 22mm;
+            max-width: 60mm;
+        }
+        .logo-fallback {
+            font-size: 32pt;
             font-weight: bold;
-            color: #1a365d;
-            margin-bottom: 10px;
+            color: #E50019;
+            letter-spacing: 4pt;
+        }
+        h1.title {
+            font-size: 48pt;
+            font-weight: bold;
+            color: #222;
+            margin: 4mm 0 2mm 0;
+            letter-spacing: 6pt;
             text-transform: uppercase;
         }
-        .subtitle {
-            font-size: 18px;
-            color: #666;
+        .reconoce {
+            font-size: 11pt;
+            color: #555;
+            letter-spacing: 4pt;
+            margin: 4mm 0 6mm 0;
+            text-transform: uppercase;
         }
         .recipient {
-            font-size: 32px;
+            font-size: 30pt;
             font-weight: bold;
-            color: #2d3748;
-            margin: 30px 0;
-            border-bottom: 2px solid #1a365d;
+            color: #E50019;
+            margin: 4mm 0 6mm 0;
+            text-transform: uppercase;
+            letter-spacing: 2pt;
+        }
+        .body-text {
+            font-size: 13pt;
+            color: #333;
+            line-height: 1.6;
+            max-width: 200mm;
+            margin: 0 auto 8mm auto;
+        }
+        .body-text strong {
+            color: #111;
+        }
+        .signature-block {
+            margin-top: 6mm;
             display: inline-block;
-            padding-bottom: 10px;
-        }
-        .course-title {
-            font-size: 24px;
-            color: #4a5568;
-            margin: 20px 0;
-        }
-        .details {
-            font-size: 16px;
-            color: #718096;
-            margin: 20px 0;
-        }
-        .footer {
-            margin-top: 40px;
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-end;
-        }
-        .signature {
             text-align: center;
+            min-width: 70mm;
+        }
+        .signature-img {
+            height: 16mm;
+            margin-bottom: 1mm;
         }
         .signature-line {
-            border-top: 1px solid #000;
-            width: 200px;
-            margin: 10px auto 5px;
+            border-top: 1px solid #333;
+            width: 70mm;
+            margin: 0 auto 2mm auto;
         }
-        .qr-code {
-            text-align: right;
+        .signer-name {
+            font-size: 11pt;
+            font-weight: bold;
+            color: #222;
         }
-        .cert-number {
-            font-size: 12px;
-            color: #a0aec0;
+        .signer-title {
+            font-size: 10pt;
+            color: #555;
+        }
+        .footer {
             position: absolute;
-            bottom: 20px;
-            left: 50%;
-            transform: translateX(-50%);
+            bottom: 6mm;
+            left: 0;
+            right: 0;
+            padding: 0 18mm;
+            font-size: 8pt;
+            color: #666;
+            z-index: 3;
+            display: table;
+            width: 100%;
         }
-        </style>
-    </head>
-    <body>
-        <div class="certificate">
-            <div class="header">
-                <div class="title">Certificado</div>
-                <div class="subtitle">S.D. S.A.S. - Sistema de Gestión de Aprendizaje</div>
-            </div>
-            <p>Se certifica que</p>
-            <div class="recipient">{{ user.get_full_name }}</div>
-            <p>ha completado satisfactoriamente el curso</p>
-            <div class="course-title">{{ course.title }}</div>
-            <div class="details">
-                {% if certificate.score %}
-                    <p>Puntaje: {{ certificate.score }}%</p>
+        .footer-text {
+            display: table-cell;
+            vertical-align: middle;
+            text-align: left;
+        }
+        .footer-qr {
+            display: table-cell;
+            vertical-align: middle;
+            text-align: right;
+            width: 22mm;
+        }
+        .footer-qr img {
+            width: 18mm;
+            height: 18mm;
+        }
+    </style>
+</head>
+<body>
+    <div class="page">
+        <div class="triangle-tl"></div>
+        <div class="triangle-br"></div>
+        <div class="content">
+            <div class="logo">
+                {% if template and template.logo %}
+                    <img src="{{ template.logo.url }}" alt="SD">
+                {% else %}
+                    <div class="logo-fallback">SD</div>
                 {% endif %}
-                <p>Fecha de emisión: {{ issued_date|date:"d \d\e F \d\e Y" }}</p>
-                {% if expires_date %}<p>Fecha de vencimiento: {{ expires_date|date:"d \d\e F \d\e Y" }}</p>{% endif %}
             </div>
-            <div class="footer">
-                <div class="signature">
-                    {% if template and template.signature_image %}
-                        <img src="{{ template.signature_image.url }}"
-                             alt="Firma"
-                             style="height: 60px">
-                    {% endif %}
-                    <div class="signature-line"></div>
-                    <div>
-                        {% if template %}{{ template.signer_name }}{% endif %}
-                    </div>
-                    <div>
-                        {% if template %}{{ template.signer_title }}{% endif %}
-                    </div>
-                </div>
-                <div class="qr-code">
-                    {% if certificate.qr_code %}
-                        <img src="{{ certificate.qr_code.url }}"
-                             alt="QR"
-                             style="width: 100px;
-                                    height: 100px">
-                    {% endif %}
-                </div>
+            <h1 class="title">Certificado</h1>
+            <div class="reconoce">Salom&oacute;n Dur&aacute;n reconoce a:</div>
+            <div class="recipient">{{ user.get_full_name|upper }}</div>
+            <div class="body-text">
+                Por haber culminado satisfactoriamente el curso de
+                <strong>{{ course.title }}</strong>
+                con una duraci&oacute;n de
+                <strong>{{ course.estimated_duration|default:"N/A" }} horas</strong>
+                a la fecha de
+                <strong>{{ issued_date|date:"d \d\e F \d\e Y" }}</strong>.
             </div>
-            <div class="cert-number">
-                Certificado No: {{ certificate_number }}
-                <br>
-                Verificar en: {{ verification_url }}
+            <div class="signature-block">
+                {% if template and template.signature_image %}
+                    <img src="{{ template.signature_image.url }}" alt="Firma" class="signature-img">
+                {% endif %}
+                <div class="signature-line"></div>
+                <div class="signer-name">
+                    {% if template and template.signer_name %}{{ template.signer_name }}{% else %}Directora HSEQ{% endif %}
+                </div>
+                <div class="signer-title">
+                    {% if template and template.signer_title %}{{ template.signer_title }}{% endif %}
+                </div>
             </div>
         </div>
-    </body>
+        <div class="footer">
+            <div class="footer-text">
+                Certificado N&deg; {{ certificate_number }} &middot; Verificar en {{ verification_url }}
+            </div>
+            <div class="footer-qr">
+                {% if certificate and certificate.qr_code %}
+                    <img src="{{ certificate.qr_code.url }}" alt="QR">
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</body>
 </html>

--- a/apps/certifications/tests/test_admin_views.py
+++ b/apps/certifications/tests/test_admin_views.py
@@ -1,0 +1,227 @@
+"""
+Tests for the custom staff admin panel of CertificateTemplate (B2 — SD#44).
+
+Covers:
+- Access control (staff_required) on all 5 views.
+- CRUD: list / create (GET+POST valid/invalid) / edit (POST updates fields).
+- Preview returns rendered HTML.
+- HTMX toggle flips is_active and returns the row partial.
+"""
+
+from datetime import date
+
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.accounts.models import User
+from apps.certifications.models import CertificateTemplate
+
+
+class _BaseAdminViewsTests(TestCase):
+    """Shared setUp: staff + non-staff user, one existing template."""
+
+    def setUp(self):
+        CertificateTemplate.objects.all().delete()
+
+        self.staff = User.objects.create_user(
+            email="staff-admin-tpl@example.com",
+            password="testpass123",
+            first_name="Staff",
+            last_name="User",
+            document_number="10000001",
+            job_position="Admin",
+            job_profile=None,
+            hire_date=date(2024, 1, 1),
+            is_staff=True,
+        )
+        self.non_staff = User.objects.create_user(
+            email="non-staff-tpl@example.com",
+            password="testpass123",
+            first_name="Regular",
+            last_name="User",
+            document_number="10000002",
+            job_position="Estudiante",
+            job_profile=None,
+            hire_date=date(2024, 1, 1),
+            is_staff=False,
+        )
+        self.template = CertificateTemplate.objects.create(
+            name="Plantilla Demo",
+            description="Plantilla para tests",
+            signer_name="Directora HSEQ",
+            signer_title="Directora",
+            is_active=True,
+        )
+
+
+class TemplateListAccessTests(_BaseAdminViewsTests):
+    def test_template_list_requires_staff(self):
+        """Non-staff users get redirected to login."""
+        self.client.force_login(self.non_staff)
+        url = reverse("certifications:template_list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_template_list_anonymous_redirected(self):
+        """Anonymous users get redirected to login."""
+        url = reverse("certifications:template_list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_template_list_staff_ok(self):
+        """Staff sees the list with existing templates."""
+        self.client.force_login(self.staff)
+        url = reverse("certifications:template_list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Plantilla Demo")
+
+
+class TemplateCreateTests(_BaseAdminViewsTests):
+    def test_template_create_get(self):
+        """GET renders the empty form for staff."""
+        self.client.force_login(self.staff)
+        url = reverse("certifications:template_create")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        # The form should be present (input for name field)
+        self.assertContains(response, 'name="name"')
+
+    def test_template_create_post_valid(self):
+        """POST with valid data creates a new template and redirects to edit."""
+        self.client.force_login(self.staff)
+        url = reverse("certifications:template_create")
+        initial_count = CertificateTemplate.objects.count()
+        response = self.client.post(
+            url,
+            data={
+                "name": "Plantilla Nueva",
+                "description": "Creada en test",
+                "signer_name": "Firma X",
+                "signer_title": "Cargo Y",
+                "is_active": "on",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            CertificateTemplate.objects.count(),
+            initial_count + 1,
+        )
+        new = CertificateTemplate.objects.get(name="Plantilla Nueva")
+        self.assertRedirects(
+            response,
+            reverse("certifications:template_edit", args=[new.pk]),
+        )
+
+    def test_template_create_post_invalid(self):
+        """POST without required `name` re-renders the form with errors."""
+        self.client.force_login(self.staff)
+        url = reverse("certifications:template_create")
+        initial_count = CertificateTemplate.objects.count()
+        response = self.client.post(
+            url,
+            data={
+                "name": "",  # required → invalid
+                "description": "sin nombre",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(CertificateTemplate.objects.count(), initial_count)
+        # form should have errors on name
+        self.assertContains(response, 'name="name"')
+
+
+class TemplateEditTests(_BaseAdminViewsTests):
+    def test_template_edit_requires_staff(self):
+        self.client.force_login(self.non_staff)
+        url = reverse("certifications:template_edit", args=[self.template.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_template_edit_get_renders_form_with_instance(self):
+        self.client.force_login(self.staff)
+        url = reverse("certifications:template_edit", args=[self.template.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Plantilla Demo")
+
+    def test_template_edit_updates_fields(self):
+        """POST update changes the instance."""
+        self.client.force_login(self.staff)
+        url = reverse("certifications:template_edit", args=[self.template.pk])
+        response = self.client.post(
+            url,
+            data={
+                "name": "Plantilla Demo Actualizada",
+                "description": self.template.description,
+                "signer_name": "Otro firmante",
+                "signer_title": "Otro cargo",
+                "is_active": "on",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.template.refresh_from_db()
+        self.assertEqual(self.template.name, "Plantilla Demo Actualizada")
+        self.assertEqual(self.template.signer_name, "Otro firmante")
+
+
+class TemplatePreviewTests(_BaseAdminViewsTests):
+    def test_template_preview_requires_staff(self):
+        self.client.force_login(self.non_staff)
+        url = reverse("certifications:template_preview", args=[self.template.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_template_preview_renders(self):
+        """Preview returns 200 with HTML content."""
+        self.client.force_login(self.staff)
+        url = reverse("certifications:template_preview", args=[self.template.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        # Should contain some text from the default template OR preview marker
+        body = response.content.decode("utf-8")
+        self.assertTrue(
+            "CERTIFICADO" in body.upper()
+            or "PREVIEW" in body.upper()
+            or self.template.name in body,
+            f"Preview output does not look like a certificate. Got: {body[:200]}",
+        )
+
+
+class TemplateToggleActiveTests(_BaseAdminViewsTests):
+    def test_template_toggle_requires_staff(self):
+        self.client.force_login(self.non_staff)
+        url = reverse(
+            "certifications:template_toggle_active",
+            args=[self.template.pk],
+        )
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_template_toggle_active_flips_value(self):
+        """POST flips is_active and returns the row partial."""
+        self.client.force_login(self.staff)
+        original = self.template.is_active
+        url = reverse(
+            "certifications:template_toggle_active",
+            args=[self.template.pk],
+        )
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+        self.template.refresh_from_db()
+        self.assertEqual(self.template.is_active, not original)
+        # Hit again → flips back
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+        self.template.refresh_from_db()
+        self.assertEqual(self.template.is_active, original)
+
+    def test_template_toggle_get_not_allowed(self):
+        """GET on toggle endpoint should be 405."""
+        self.client.force_login(self.staff)
+        url = reverse(
+            "certifications:template_toggle_active",
+            args=[self.template.pk],
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 405)

--- a/apps/certifications/tests/test_download.py
+++ b/apps/certifications/tests/test_download.py
@@ -1,0 +1,235 @@
+"""
+Tests for the certificate_download view (FileResponse-based PDF download).
+
+Covers:
+- Login required
+- Owner can download
+- Staff can download any certificate
+- Other users get 403
+- Revoked certificates are blocked
+- Expired certificates are blocked
+- Missing file returns 404
+"""
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from django.core.files.base import ContentFile
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.certifications.models import Certificate, CertificateTemplate
+from apps.courses.models import Course
+
+
+# Minimal valid PDF (header + EOF) — large enough to be a real-ish file.
+MINIMAL_PDF = (
+    b"%PDF-1.4\n"
+    b"1 0 obj<<>>endobj\n"
+    b"trailer<<>>\n"
+    b"%%EOF\n"
+)
+
+
+@override_settings(
+    STORAGES={
+        "default": {"BACKEND": "django.core.files.storage.InMemoryStorage"},
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
+        },
+    },
+)
+class CertificateDownloadTests(TestCase):
+    """Test certificate_download view enforces auth, ownership and status."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = User.objects.create_user(
+            email="admin@test.com",
+            password="testpass123",
+            first_name="Admin",
+            last_name="User",
+            document_number="100000001",
+            job_position="Administrator",
+            hire_date=date(2020, 1, 1),
+            is_staff=True,
+        )
+        cls.owner = User.objects.create_user(
+            email="owner@test.com",
+            password="testpass123",
+            first_name="Juan",
+            last_name="Pérez",
+            document_number="100000002",
+            job_position="Technician",
+            hire_date=date(2021, 1, 1),
+        )
+        cls.other = User.objects.create_user(
+            email="other@test.com",
+            password="testpass123",
+            first_name="Pedro",
+            last_name="Gómez",
+            document_number="100000003",
+            job_position="Technician",
+            hire_date=date(2021, 1, 1),
+        )
+
+        cls.course = Course.objects.create(
+            code="DL-001",
+            title="Curso de prueba descarga",
+            created_by=cls.admin,
+            status=Course.Status.PUBLISHED,
+            validity_months=12,
+        )
+        cls.template = CertificateTemplate.objects.create(
+            name="Plantilla descarga",
+            signer_name="Directora HSEQ",
+            signer_title="S.D. S.A.S.",
+            is_active=True,
+        )
+
+    def _make_certificate(
+        self,
+        *,
+        user=None,
+        status=Certificate.Status.ISSUED,
+        with_file=True,
+        expires_at=None,
+        number_suffix="A",
+    ):
+        """Create a certificate (optionally with attached PDF content)."""
+        user = user or self.owner
+        cert = Certificate.objects.create(
+            user=user,
+            course=self.course,
+            template=self.template,
+            certificate_number=f"CERT-2026-{number_suffix}",
+            status=status,
+            issued_at=timezone.now() if status == Certificate.Status.ISSUED else None,
+            expires_at=expires_at,
+        )
+        if with_file:
+            cert.certificate_file.save(
+                f"{cert.certificate_number}.pdf",
+                ContentFile(MINIMAL_PDF),
+                save=True,
+            )
+        return cert
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+    def test_download_requires_login(self):
+        """Anonymous user must be redirected to login."""
+        cert = self._make_certificate(number_suffix="ANON")
+        url = reverse("certifications:download", args=[cert.id])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("login", response["Location"].lower())
+
+    # ------------------------------------------------------------------
+    # Happy path: owner
+    # ------------------------------------------------------------------
+    def test_download_owner_ok(self):
+        """Owner can download — response is PDF, attachment, with bytes."""
+        cert = self._make_certificate(number_suffix="OWN")
+        self.client.force_login(self.owner)
+        url = reverse("certifications:download", args=[cert.id])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        disposition = response.get("Content-Disposition", "")
+        self.assertIn("attachment", disposition)
+        self.assertIn(f"Certificado_{cert.certificate_number}.pdf", disposition)
+        # Drain streaming content and check it starts with PDF magic.
+        body = b"".join(response.streaming_content)
+        self.assertTrue(body.startswith(b"%PDF"))
+
+    # ------------------------------------------------------------------
+    # AuthZ
+    # ------------------------------------------------------------------
+    def test_download_other_user_forbidden(self):
+        """Another (non-owner, non-staff) user gets 403."""
+        cert = self._make_certificate(number_suffix="OTH")
+        self.client.force_login(self.other)
+        url = reverse("certifications:download", args=[cert.id])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_download_staff_ok(self):
+        """Staff can download any certificate."""
+        cert = self._make_certificate(number_suffix="STF")
+        self.client.force_login(self.admin)
+        url = reverse("certifications:download", args=[cert.id])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+
+    # ------------------------------------------------------------------
+    # Status guards
+    # ------------------------------------------------------------------
+    def test_download_revoked_blocked(self):
+        """Revoked certs cannot be downloaded (403)."""
+        cert = self._make_certificate(
+            status=Certificate.Status.REVOKED,
+            number_suffix="REV",
+        )
+        self.client.force_login(self.owner)
+        url = reverse("certifications:download", args=[cert.id])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_download_expired_blocked(self):
+        """Certificates with expires_at in the past cannot be downloaded (403)."""
+        past = timezone.now() - timedelta(days=1)
+        cert = self._make_certificate(
+            status=Certificate.Status.ISSUED,
+            expires_at=past,
+            number_suffix="EXP",
+        )
+        self.client.force_login(self.owner)
+        url = reverse("certifications:download", args=[cert.id])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 403)
+
+    # ------------------------------------------------------------------
+    # File missing
+    # ------------------------------------------------------------------
+    def test_download_no_file_404(self):
+        """Issued cert without a file returns 404 from not_available template."""
+        cert = self._make_certificate(with_file=False, number_suffix="NOF")
+        self.client.force_login(self.owner)
+        url = reverse("certifications:download", args=[cert.id])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_download_file_not_found_on_storage_returns_404(self):
+        """If the FieldFile points to a missing blob, view returns 404."""
+        cert = self._make_certificate(number_suffix="FNF")
+        self.client.force_login(self.owner)
+        url = reverse("certifications:download", args=[cert.id])
+
+        # Simulate the underlying storage not having the file anymore.
+        with patch.object(
+            cert.certificate_file.storage,
+            "open",
+            side_effect=FileNotFoundError(),
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 404)

--- a/apps/certifications/tests/test_e2e.py
+++ b/apps/certifications/tests/test_e2e.py
@@ -1,0 +1,205 @@
+"""
+E2E acceptance test for the certificados module (SD#43, SD#44).
+
+Exercises the full flow:
+  1. Staff creates a CertificateTemplate via the custom panel (B2 — SD#44).
+  2. Student enrolls in a course, completes it (status=COMPLETED).
+  3. The post_save signal automatically issues a Certificate (B1 — SD#43).
+  4. Student downloads the PDF via the FileResponse endpoint (B3 — SD#43).
+
+Uses TransactionTestCase so that `transaction.on_commit` callbacks fire
+during the test (TestCase wraps each test in a never-committed transaction,
+which would swallow the signal callback).
+"""
+
+from datetime import date
+from unittest.mock import patch
+
+from django.core.files.base import ContentFile
+from django.test import TransactionTestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.certifications.models import Certificate, CertificateTemplate
+from apps.certifications.services import CertificateService
+from apps.courses.models import Course, Enrollment
+
+
+# Minimal valid PDF (header + EOF) — large enough to be a real-ish file.
+MINIMAL_PDF = b"%PDF-1.4\n%test certificate e2e\n" + b"x" * 500 + b"\n%%EOF\n"
+
+
+def _fake_generate_certificate_file(certificate):
+    """
+    Mock that mimics CertificateService.generate_certificate_file without
+    invoking weasyprint / qrcode (which may not be available in the test
+    env). Persists a minimal PDF blob on the certificate and marks it as
+    ISSUED so the full flow can continue end-to-end.
+    """
+    certificate.certificate_file.save(
+        f"cert_{certificate.certificate_number}.pdf",
+        ContentFile(MINIMAL_PDF),
+        save=False,
+    )
+    certificate.status = Certificate.Status.ISSUED
+    certificate.issued_at = timezone.now()
+    certificate.verification_url = (
+        f"https://example.com/verify/{certificate.certificate_number}/"
+    )
+    certificate.save()
+    return certificate
+
+
+@override_settings(
+    STORAGES={
+        "default": {"BACKEND": "django.core.files.storage.InMemoryStorage"},
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
+        },
+    },
+)
+class CertificadosE2ETest(TransactionTestCase):
+    """End-to-end flow covering B1 + B2 + B3."""
+
+    def setUp(self):
+        # Clean templates from any prior test that may have leaked rows
+        # (TransactionTestCase truncates between tests but be defensive).
+        CertificateTemplate.objects.all().delete()
+
+        # Staff user — will create the template via the custom panel.
+        self.staff = User.objects.create_user(
+            email="staff-e2e@example.com",
+            password="testpass123",
+            first_name="Admin",
+            last_name="Staff",
+            document_number="900000010",
+            job_position="Administrator",
+            hire_date=date(2020, 1, 1),
+            is_staff=True,
+        )
+        # Student — will complete the course and download the cert.
+        self.student = User.objects.create_user(
+            email="student-e2e@example.com",
+            password="testpass123",
+            first_name="Juan",
+            last_name="Estudiante",
+            document_number="900000011",
+            job_position="Technician",
+            hire_date=date(2021, 6, 15),
+        )
+        # Course already published.
+        self.course = Course.objects.create(
+            code="E2E-001",
+            title="Curso E2E",
+            description="Descripción del curso E2E",
+            created_by=self.staff,
+            status=Course.Status.PUBLISHED,
+            validity_months=12,
+        )
+
+    @patch.object(
+        CertificateService,
+        "generate_certificate_file",
+        side_effect=_fake_generate_certificate_file,
+    )
+    def test_full_flow_template_enroll_complete_download(self, mock_gen):
+        """Template → enrollment → completed → signal → download."""
+
+        # ---- B2 (SD#44): staff creates template via custom panel ----
+        self.client.force_login(self.staff)
+        resp = self.client.post(
+            reverse("certifications:template_create"),
+            data={
+                "name": "Plantilla E2E",
+                "description": "Plantilla para test E2E",
+                "signer_name": "Directora HSEQ",
+                "signer_title": "HSEQ",
+                "is_active": "on",
+            },
+        )
+        self.assertEqual(resp.status_code, 302)
+        template = CertificateTemplate.objects.get(name="Plantilla E2E")
+        self.assertTrue(template.is_active)
+
+        # ---- B1 (SD#43): enrollment COMPLETED triggers signal ----
+        enrollment = Enrollment.objects.create(
+            user=self.student,
+            course=self.course,
+            status=Enrollment.Status.IN_PROGRESS,
+            progress=50,
+        )
+        self.assertFalse(
+            Certificate.objects.filter(
+                user=self.student, course=self.course
+            ).exists()
+        )
+
+        # Transition IN_PROGRESS -> COMPLETED. Signal fires on commit and
+        # invokes our mocked generator, which attaches the PDF blob.
+        enrollment.status = Enrollment.Status.COMPLETED
+        enrollment.progress = 100
+        enrollment.save()
+
+        cert = Certificate.objects.get(user=self.student, course=self.course)
+        self.assertEqual(cert.status, Certificate.Status.ISSUED)
+        self.assertTrue(cert.certificate_file)
+        # Generator was actually invoked exactly once for this enrollment.
+        self.assertGreaterEqual(mock_gen.call_count, 1)
+
+        # ---- B3 (SD#43): student downloads PDF via FileResponse ----
+        self.client.force_login(self.student)
+        resp = self.client.get(
+            reverse("certifications:download", args=[cert.pk])
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["Content-Type"], "application/pdf")
+        disposition = resp.get("Content-Disposition", "")
+        self.assertIn("attachment", disposition)
+        self.assertIn(
+            f"Certificado_{cert.certificate_number}.pdf", disposition
+        )
+
+        body = b"".join(resp.streaming_content)
+        self.assertTrue(body.startswith(b"%PDF"))
+        self.assertGreater(len(body), 200)
+
+    @patch.object(
+        CertificateService,
+        "generate_certificate_file",
+        side_effect=_fake_generate_certificate_file,
+    )
+    def test_signal_idempotent_across_two_completes(self, mock_gen):
+        """Re-saving a COMPLETED enrollment does not issue a second cert."""
+
+        # Seed an active template so the signal has something to pick up.
+        CertificateTemplate.objects.create(
+            name="Plantilla Idempotent",
+            signer_name="Director",
+            signer_title="S.D. S.A.S.",
+            is_active=True,
+        )
+
+        enrollment = Enrollment.objects.create(
+            user=self.student,
+            course=self.course,
+            status=Enrollment.Status.COMPLETED,
+            progress=100,
+        )
+
+        # First save -> 1 cert exists.
+        self.assertEqual(
+            Certificate.objects.filter(
+                user=self.student, course=self.course
+            ).count(),
+            1,
+        )
+
+        # Re-save without changing status -> still exactly 1 cert.
+        enrollment.save()
+        self.assertEqual(
+            Certificate.objects.filter(
+                user=self.student, course=self.course
+            ).count(),
+            1,
+        )

--- a/apps/certifications/tests/test_signals.py
+++ b/apps/certifications/tests/test_signals.py
@@ -1,0 +1,164 @@
+"""
+Tests for certifications signals.
+
+Covers the post_save Enrollment -> auto-issue Certificate signal
+(`issue_certificate_on_enrollment_completed`).
+
+Uses TransactionTestCase so that `transaction.on_commit` callbacks fire
+during the test (TestCase wraps each test in a never-committed transaction,
+which would swallow the callback).
+"""
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.certifications.models import Certificate, CertificateTemplate
+from apps.certifications.services import CertificateService
+from apps.courses.models import Course, Enrollment
+
+
+def mock_generate_certificate_file(certificate):
+    """Mock that skips PDF/QR generation and just marks the cert as issued."""
+    certificate.status = Certificate.Status.ISSUED
+    certificate.issued_at = timezone.now()
+    certificate.verification_url = (
+        f"https://example.com/verify/{certificate.certificate_number}/"
+    )
+    certificate.save()
+    return certificate
+
+
+@patch.object(
+    CertificateService,
+    "generate_certificate_file",
+    side_effect=mock_generate_certificate_file,
+)
+class EnrollmentCompletionSignalTest(TransactionTestCase):
+    """Tests for issue_certificate_on_enrollment_completed signal."""
+
+    def setUp(self):
+        self.admin = User.objects.create_user(
+            email="admin-signals@test.com",
+            password="testpass123",
+            first_name="Admin",
+            last_name="User",
+            document_number="900000001",
+            job_position="Administrator",
+            hire_date=date(2020, 1, 1),
+            is_staff=True,
+        )
+        self.user = User.objects.create_user(
+            email="user-signals@test.com",
+            password="testpass123",
+            first_name="Juan",
+            last_name="Perez",
+            document_number="900000002",
+            job_position="Technician",
+            hire_date=date(2021, 6, 15),
+        )
+        self.course = Course.objects.create(
+            code="SIG-001",
+            title="Signal Test Course",
+            created_by=self.admin,
+            status=Course.Status.PUBLISHED,
+            validity_months=12,
+        )
+        self.template = CertificateTemplate.objects.create(
+            name="Default Template (signals)",
+            signer_name="Director",
+            signer_title="S.D. S.A.S.",
+            is_active=True,
+        )
+
+    def test_signal_issues_certificate_on_completed(self, mock_gen):
+        """When enrollment goes IN_PROGRESS -> COMPLETED, a cert is issued."""
+        enrollment = Enrollment.objects.create(
+            user=self.user,
+            course=self.course,
+            status=Enrollment.Status.IN_PROGRESS,
+            progress=50,
+        )
+
+        # No cert yet (status != COMPLETED)
+        self.assertEqual(
+            Certificate.objects.filter(user=self.user, course=self.course).count(),
+            0,
+        )
+
+        # Transition to COMPLETED -> signal should fire on commit
+        enrollment.status = Enrollment.Status.COMPLETED
+        enrollment.progress = 100
+        enrollment.save()
+
+        certs = Certificate.objects.filter(user=self.user, course=self.course)
+        self.assertEqual(certs.count(), 1)
+        self.assertEqual(certs.first().status, Certificate.Status.ISSUED)
+
+    def test_signal_idempotent(self, mock_gen):
+        """Re-saving a COMPLETED enrollment does not duplicate the certificate."""
+        enrollment = Enrollment.objects.create(
+            user=self.user,
+            course=self.course,
+            status=Enrollment.Status.COMPLETED,
+            progress=100,
+        )
+
+        self.assertEqual(
+            Certificate.objects.filter(user=self.user, course=self.course).count(),
+            1,
+        )
+
+        # Re-save without changing status -> still 1 cert
+        enrollment.save()
+        self.assertEqual(
+            Certificate.objects.filter(user=self.user, course=self.course).count(),
+            1,
+        )
+
+    def test_signal_skips_when_not_completed(self, mock_gen):
+        """No cert is issued when enrollment is created in IN_PROGRESS."""
+        Enrollment.objects.create(
+            user=self.user,
+            course=self.course,
+            status=Enrollment.Status.IN_PROGRESS,
+            progress=50,
+        )
+
+        self.assertEqual(
+            Certificate.objects.filter(user=self.user, course=self.course).count(),
+            0,
+        )
+
+    def test_signal_skips_when_existing_issued_cert(self, mock_gen):
+        """If a valid ISSUED cert already exists, signal does not create another."""
+        # Pre-create an ISSUED certificate manually
+        Certificate.objects.create(
+            user=self.user,
+            course=self.course,
+            certificate_number="SD-PRESEED-00000001",
+            status=Certificate.Status.ISSUED,
+            issued_at=timezone.now(),
+            expires_at=timezone.now() + timedelta(days=365),
+        )
+        self.assertEqual(
+            Certificate.objects.filter(user=self.user, course=self.course).count(),
+            1,
+        )
+
+        # Now flip the enrollment to COMPLETED
+        Enrollment.objects.create(
+            user=self.user,
+            course=self.course,
+            status=Enrollment.Status.COMPLETED,
+            progress=100,
+        )
+
+        # Still exactly 1 cert (the pre-seeded one); signal short-circuited.
+        self.assertEqual(
+            Certificate.objects.filter(user=self.user, course=self.course).count(),
+            1,
+        )

--- a/apps/certifications/urls.py
+++ b/apps/certifications/urls.py
@@ -17,4 +17,22 @@ urlpatterns = [
     path("<int:certificate_id>/download/", views.certificate_download, name="download"),
     path("verify/", views.verify_certificate, name="verify"),
     path("verify/<str:certificate_number>/", views.verify_certificate, name="verify_number"),
+    # Staff admin panel (B2)
+    path("admin/templates/", views.template_list, name="template_list"),
+    path("admin/templates/new/", views.template_create, name="template_create"),
+    path(
+        "admin/templates/<int:template_id>/edit/",
+        views.template_edit,
+        name="template_edit",
+    ),
+    path(
+        "admin/templates/<int:template_id>/preview/",
+        views.template_preview,
+        name="template_preview",
+    ),
+    path(
+        "admin/templates/<int:template_id>/toggle/",
+        views.template_toggle_active,
+        name="template_toggle_active",
+    ),
 ]

--- a/apps/certifications/views.py
+++ b/apps/certifications/views.py
@@ -3,6 +3,7 @@ Web views for certifications app.
 """
 
 from django.contrib.auth.decorators import login_required
+from django.http import FileResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 
@@ -120,9 +121,24 @@ def certificate_download(request, certificate_id):
 
     if not certificate.certificate_file:
         context = {"message": "El archivo del certificado no está disponible."}
-        return render(request, "certifications/not_available.html", context)
+        return render(request, "certifications/not_available.html", context, status=404)
 
-    # Redirect to file URL (in production would serve directly)
-    from django.http import HttpResponseRedirect
+    # Serve PDF directly via FileResponse (streams + correct content-type + as_attachment)
+    # This avoids relying on a public GCS bucket URL or signed-URL expiration.
+    try:
+        # certificate_file is a FieldFile; .open("rb") returns a file handle that
+        # FileResponse will iterate over and close after streaming.
+        file_handle = certificate.certificate_file.open("rb")
+    except FileNotFoundError:
+        context = {
+            "message": "El archivo del certificado no está disponible (FileNotFound)."
+        }
+        return render(request, "certifications/not_available.html", context, status=404)
 
-    return HttpResponseRedirect(certificate.certificate_file.url)
+    response = FileResponse(
+        file_handle,
+        as_attachment=True,
+        filename=f"Certificado_{certificate.certificate_number}.pdf",
+        content_type="application/pdf",
+    )
+    return response

--- a/apps/certifications/views.py
+++ b/apps/certifications/views.py
@@ -126,3 +126,95 @@ def certificate_download(request, certificate_id):
     from django.http import HttpResponseRedirect
 
     return HttpResponseRedirect(certificate.certificate_file.url)
+
+
+# ---------------------------------------------------------------------------
+# B2 — Staff admin panel for CertificateTemplate
+# ---------------------------------------------------------------------------
+
+from django.contrib import messages  # noqa: E402
+from django.contrib.auth.decorators import user_passes_test  # noqa: E402
+from django.http import HttpResponse  # noqa: E402
+from django.shortcuts import redirect  # noqa: E402
+from django.views.decorators.http import require_http_methods  # noqa: E402
+
+from .forms import CertificateTemplateForm  # noqa: E402
+from .models import CertificateTemplate  # noqa: E402
+from .services import CertificateTemplateService  # noqa: E402
+
+
+def _staff_required(view):
+    """Decorator: only staff users can access."""
+    return user_passes_test(lambda u: u.is_authenticated and u.is_staff)(view)
+
+
+@_staff_required
+def template_list(request):
+    """List all certificate templates for staff to manage."""
+    templates = CertificateTemplate.objects.all().order_by("-is_active", "name")
+    return render(
+        request,
+        "certifications/admin/template_list.html",
+        {"templates": templates},
+    )
+
+
+@_staff_required
+@require_http_methods(["GET", "POST"])
+def template_create(request):
+    """Create a new certificate template."""
+    if request.method == "POST":
+        form = CertificateTemplateForm(request.POST, request.FILES)
+        if form.is_valid():
+            template = form.save()
+            messages.success(request, f"Plantilla '{template.name}' creada.")
+            return redirect("certifications:template_edit", template_id=template.pk)
+    else:
+        form = CertificateTemplateForm()
+    return render(
+        request,
+        "certifications/admin/template_form.html",
+        {"form": form, "template": None, "action": "create"},
+    )
+
+
+@_staff_required
+@require_http_methods(["GET", "POST"])
+def template_edit(request, template_id):
+    """Edit an existing certificate template."""
+    template = get_object_or_404(CertificateTemplate, pk=template_id)
+    if request.method == "POST":
+        form = CertificateTemplateForm(request.POST, request.FILES, instance=template)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Plantilla actualizada.")
+            return redirect("certifications:template_edit", template_id=template.pk)
+    else:
+        form = CertificateTemplateForm(instance=template)
+    return render(
+        request,
+        "certifications/admin/template_form.html",
+        {"form": form, "template": template, "action": "edit"},
+    )
+
+
+@_staff_required
+def template_preview(request, template_id):
+    """Render a HTML preview of the template with sample data."""
+    template = get_object_or_404(CertificateTemplate, pk=template_id)
+    html = CertificateTemplateService.preview_template(template)
+    return HttpResponse(html)
+
+
+@_staff_required
+@require_http_methods(["POST"])
+def template_toggle_active(request, template_id):
+    """Activate/deactivate a template (HTMX target)."""
+    template = get_object_or_404(CertificateTemplate, pk=template_id)
+    template.is_active = not template.is_active
+    template.save(update_fields=["is_active", "updated_at"])
+    return render(
+        request,
+        "certifications/admin/_template_row.html",
+        {"t": template},
+    )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,6 +42,9 @@ django-allauth>=0.63.1
 # Storage
 django-storages>=1.14.2
 Pillow>=10.3.0,<11
+weasyprint>=62.0,<63
+qrcode[pil]>=7.4,<8
+reportlab>=4.2,<5
 
 # Cache
 django-redis>=5.4.0

--- a/templates/certifications/certificate_detail.html
+++ b/templates/certifications/certificate_detail.html
@@ -1,141 +1,211 @@
 {% extends "base/dashboard.html" %}
-{% block page_title %}Certificado{% endblock %}
+{% load static %}
+
+{% block page_title %}Certificado N° {{ certificate.certificate_number }}{% endblock %}
+
 {% block page_description %}
-    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 font-mono">{{ certificate.certificate_number }}</p>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {{ certificate.course.title }} — {{ certificate.user.get_full_name }}
+    </p>
 {% endblock %}
-{% block main_classes %}lg:col-span-3{% endblock %}
-{% block sidebar %}
-    <div class="lg:col-span-1">
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 sticky top-4">
-            <!-- Status -->
-            <div class="text-center mb-4">
-                <span class="badge badge-lg {% if certificate.status == 'issued' %}badge-success {% elif certificate.status == 'revoked' %}badge-error {% elif certificate.status == 'expired' %}badge-warning {% else %}badge-ghost{% endif %}">
-                    {{ certificate.get_status_display }}
-                </span>
-            </div>
-            <!-- QR Code -->
-            {% if certificate.qr_code %}
-                <div class="text-center mb-4">
-                    <img src="{{ certificate.qr_code.url }}"
-                         alt="QR de verificación"
-                         class="mx-auto w-32 h-32">
-                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">Escanea para verificar</p>
+
+{% block dashboard_content %}
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <!-- Main column: PDF preview + data -->
+        <div class="lg:col-span-2 space-y-6">
+            <!-- Status banner -->
+            {% if certificate.status == 'revoked' %}
+                <div class="alert alert-error">
+                    <svg xmlns="http://www.w3.org/2000/svg"
+                         class="stroke-current shrink-0 h-6 w-6"
+                         fill="none"
+                         viewBox="0 0 24 24">
+                        <path stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <div>
+                        <h3 class="font-bold">Certificado revocado</h3>
+                        {% if certificate.revoked_at %}
+                            <div class="text-xs">Revocado el {{ certificate.revoked_at|date:"d M Y H:i" }}</div>
+                        {% endif %}
+                        {% if certificate.revoked_reason %}
+                            <div class="text-xs mt-1">Motivo: {{ certificate.revoked_reason }}</div>
+                        {% endif %}
+                    </div>
+                </div>
+            {% elif certificate.status == 'expired' %}
+                <div class="alert alert-warning">
+                    <span>Este certificado está vencido.</span>
+                </div>
+            {% elif certificate.status == 'pending' %}
+                <div class="alert alert-info">
+                    <span>El certificado está pendiente de emisión.</span>
                 </div>
             {% endif %}
-            <!-- Actions -->
-            <div class="space-y-2">
-                {% if certificate.certificate_file %}
-                    <a href="{% url 'certifications:download' certificate.id %}"
-                       class="btn btn-primary btn-block">
-                        <svg class="w-4 h-4 mr-2"
-                             fill="none"
-                             stroke="currentColor"
-                             viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                        </svg>
-                        Descargar PDF
-                    </a>
-                {% endif %}
-                <a href="{% url 'certifications:verify_number' certificate.certificate_number %}"
-                   class="btn btn-ghost btn-block"
-                   target="_blank">
-                    <svg class="w-4 h-4 mr-2"
-                         fill="none"
-                         stroke="currentColor"
-                         viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-                    </svg>
-                    Verificar Certificado
-                </a>
-                <a href="{% url 'certifications:my_certificates' %}"
-                   class="btn btn-ghost btn-block">Volver a Certificados</a>
-            </div>
-        </div>
-    </div>
-{% endblock %}
-{% block dashboard_content %}
-    <div class="space-y-6">
-        <!-- Certificate Preview -->
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
-            <!-- Header -->
-            <div class="h-48 bg-gradient-to-br from-primary to-secondary flex items-center justify-center">
-                <div class="text-center text-white">
-                    <svg class="w-16 h-16 mx-auto mb-2 opacity-80"
-                         fill="none"
-                         stroke="currentColor"
-                         viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-                    </svg>
-                    <h2 class="text-2xl font-bold">Certificado de Completación</h2>
-                </div>
-            </div>
-            <!-- Content -->
-            <div class="p-8 text-center">
-                <p class="text-gray-600 dark:text-gray-400 mb-2">Se certifica que</p>
-                <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">{{ certificate.user.get_full_name }}</h3>
-                <p class="text-gray-600 dark:text-gray-400 mb-2">ha completado satisfactoriamente el curso</p>
-                <h4 class="text-xl font-semibold text-primary mb-6">{{ certificate.course.title }}</h4>
-                {% if certificate.score %}
-                    <p class="text-gray-600 dark:text-gray-400 mb-4">
-                        Con un puntaje de <span class="font-bold text-success">{{ certificate.score|floatformat:0 }}%</span>
-                    </p>
-                {% endif %}
-                <div class="border-t dark:border-gray-700 pt-6 mt-6">
-                    <p class="text-sm text-gray-500 dark:text-gray-400">
-                        Certificado No. <span class="font-mono">{{ certificate.certificate_number }}</span>
-                    </p>
-                    {% if certificate.issued_at %}
-                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Emitido el {{ certificate.issued_at|date:"d de F de Y" }}</p>
+
+            <!-- PDF preview -->
+            <div class="card bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700">
+                <div class="card-body p-0">
+                    <div class="px-5 py-3 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+                        <h2 class="font-semibold text-gray-900 dark:text-white">
+                            Vista previa del certificado
+                        </h2>
+                        {% if certificate.certificate_file and certificate.status == 'issued' %}
+                            <a href="{% url 'certifications:download' certificate.id %}"
+                               class="btn btn-sm btn-primary">
+                                <svg xmlns="http://www.w3.org/2000/svg"
+                                     class="w-4 h-4 mr-1"
+                                     fill="none"
+                                     viewBox="0 0 24 24"
+                                     stroke="currentColor"
+                                     stroke-width="2">
+                                    <path stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                </svg>
+                                Descargar PDF
+                            </a>
+                        {% endif %}
+                    </div>
+                    {% if certificate.certificate_file %}
+                        <iframe src="{{ certificate.certificate_file.url }}"
+                                class="w-full"
+                                style="height: 600px; border: 0;"
+                                title="Vista previa del certificado {{ certificate.certificate_number }}">
+                        </iframe>
+                    {% else %}
+                        <div class="p-10 text-center text-gray-500 dark:text-gray-400">
+                            <p>La vista previa del PDF no está disponible.</p>
+                        </div>
                     {% endif %}
                 </div>
             </div>
-        </div>
-        <!-- Certificate Details -->
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Detalles del Certificado</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">Titular</p>
-                    <p class="font-medium text-gray-900 dark:text-white">{{ certificate.user.get_full_name }}</p>
-                </div>
-                <div>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">Correo</p>
-                    <p class="font-medium text-gray-900 dark:text-white">{{ certificate.user.email }}</p>
-                </div>
-                <div>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">Curso</p>
-                    <p class="font-medium text-gray-900 dark:text-white">{{ certificate.course.title }}</p>
-                </div>
-                <div>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">Código del curso</p>
-                    <p class="font-medium text-gray-900 dark:text-white">{{ certificate.course.code }}</p>
-                </div>
-                {% if certificate.issued_at %}
-                    <div>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">Fecha de emisión</p>
-                        <p class="font-medium text-gray-900 dark:text-white">{{ certificate.issued_at|date:"d M Y" }}</p>
+
+            <!-- Certificate details -->
+            <div class="card bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700">
+                <div class="card-body">
+                    <h2 class="card-title text-gray-900 dark:text-white">Datos del certificado</h2>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-3">
+                        <div>
+                            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Titular</p>
+                            <p class="font-medium text-gray-900 dark:text-white">
+                                {{ certificate.user.get_full_name }}
+                            </p>
+                        </div>
+                        <div>
+                            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Correo</p>
+                            <p class="font-medium text-gray-900 dark:text-white">
+                                {{ certificate.user.email }}
+                            </p>
+                        </div>
+                        <div>
+                            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Curso</p>
+                            <p class="font-medium text-gray-900 dark:text-white">
+                                {{ certificate.course.title }}
+                            </p>
+                        </div>
+                        <div>
+                            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Estado</p>
+                            <span class="badge {% if certificate.status == 'issued' %}badge-success{% elif certificate.status == 'expired' %}badge-warning{% elif certificate.status == 'revoked' %}badge-error{% else %}badge-info{% endif %}">
+                                {{ certificate.get_status_display }}
+                            </span>
+                        </div>
+                        {% if certificate.score %}
+                            <div>
+                                <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Puntaje</p>
+                                <p class="font-medium text-gray-900 dark:text-white">
+                                    {{ certificate.score|floatformat:0 }}%
+                                </p>
+                            </div>
+                        {% endif %}
+                        {% if certificate.issued_at %}
+                            <div>
+                                <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Emitido</p>
+                                <p class="font-medium text-gray-900 dark:text-white">
+                                    {{ certificate.issued_at|date:"d M Y H:i" }}
+                                </p>
+                            </div>
+                        {% endif %}
+                        {% if certificate.expires_at %}
+                            <div>
+                                <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Vence</p>
+                                <p class="font-medium text-gray-900 dark:text-white">
+                                    {{ certificate.expires_at|date:"d M Y" }}
+                                </p>
+                            </div>
+                        {% endif %}
+                        {% if certificate.verification_url %}
+                            <div class="sm:col-span-2">
+                                <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">URL de verificación</p>
+                                <p class="font-mono text-sm text-primary-600 dark:text-primary-400 break-all">
+                                    <a href="{{ certificate.verification_url }}"
+                                       target="_blank"
+                                       rel="noopener noreferrer">
+                                        {{ certificate.verification_url }}
+                                    </a>
+                                </p>
+                            </div>
+                        {% endif %}
                     </div>
-                {% endif %}
-                {% if certificate.expires_at %}
-                    <div>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">Fecha de vencimiento</p>
-                        <p class="font-medium text-gray-900 dark:text-white">{{ certificate.expires_at|date:"d M Y" }}</p>
-                    </div>
-                {% endif %}
+                </div>
             </div>
         </div>
-        {% if certificate.status == 'revoked' %}
-            <div class="bg-error/10 border border-error rounded-lg p-4">
-                <h3 class="font-semibold text-error mb-2">Certificado Revocado</h3>
-                <p class="text-sm text-gray-700 dark:text-gray-300">
-                    Este certificado fue revocado el {{ certificate.revoked_at|date:"d M Y" }}.
-                </p>
-                {% if certificate.revoked_reason %}
-                    <p class="text-sm text-gray-600 dark:text-gray-400 mt-2">
-                        <span class="font-medium">Motivo:</span> {{ certificate.revoked_reason }}
-                    </p>
-                {% endif %}
+
+        <!-- Sidebar: actions -->
+        <div class="lg:col-span-1">
+            <div class="card bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 sticky top-4">
+                <div class="card-body">
+                    <h3 class="card-title text-gray-900 dark:text-white">Acciones</h3>
+
+                    {% if certificate.qr_code %}
+                        <div class="text-center mb-4">
+                            <img src="{{ certificate.qr_code.url }}"
+                                 alt="QR de verificación"
+                                 class="mx-auto w-32 h-32 border border-gray-200 dark:border-gray-700 rounded">
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                                Escanea para verificar
+                            </p>
+                        </div>
+                    {% endif %}
+
+                    <div class="space-y-2">
+                        {% if certificate.certificate_file and certificate.status == 'issued' %}
+                            <a href="{% url 'certifications:download' certificate.id %}"
+                               class="btn btn-primary btn-block">
+                                Descargar PDF
+                            </a>
+                        {% endif %}
+                        {% if certificate.verification_url %}
+                            <button type="button"
+                                    class="btn btn-outline btn-block"
+                                    x-data="{ copied: false }"
+                                    @click="navigator.clipboard.writeText('{{ certificate.verification_url|escapejs }}'); copied = true; setTimeout(() => copied = false, 2000)"
+                                    :class="{ 'btn-success': copied }">
+                                <span x-show="!copied">Compartir verificación</span>
+                                <span x-show="copied" x-cloak>¡URL copiada!</span>
+                            </button>
+                        {% endif %}
+                        <a href="{% url 'certifications:my_certificates' %}"
+                           class="btn btn-ghost btn-block">
+                            Volver a mis certificados
+                        </a>
+
+                        {% if user.is_staff %}
+                            <div class="divider text-xs text-gray-400 dark:text-gray-500">Staff</div>
+                            <a href="{% url 'admin:certifications_certificate_change' certificate.id %}"
+                               class="btn btn-outline btn-error btn-sm btn-block">
+                                Revocar (admin)
+                            </a>
+                            <a href="{% url 'admin:certifications_certificate_change' certificate.id %}"
+                               class="btn btn-outline btn-warning btn-sm btn-block">
+                                Reemitir (admin)
+                            </a>
+                        {% endif %}
+                    </div>
+                </div>
             </div>
-        {% endif %}
+        </div>
     </div>
 {% endblock %}

--- a/templates/certifications/my_certificates.html
+++ b/templates/certifications/my_certificates.html
@@ -1,99 +1,163 @@
 {% extends "base/dashboard.html" %}
+{% load static %}
+
 {% block page_title %}Mis Certificados{% endblock %}
+
 {% block page_description %}
-    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Gestiona y descarga tus certificados obtenidos</p>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        Consulta, descarga y comparte los certificados que has obtenido al completar tus cursos.
+    </p>
 {% endblock %}
+
 {% block dashboard_content %}
-    <!-- Status Tabs -->
-    <div class="tabs tabs-boxed mb-6 bg-white dark:bg-gray-800 p-1">
+    <!-- Filter chips by status -->
+    <div class="flex flex-wrap gap-2 mb-6">
         <a href="{% url 'certifications:my_certificates' %}"
-           class="tab {% if not current_status %}tab-active{% endif %}">Todos</a>
+           class="badge badge-lg cursor-pointer {% if not current_status %}badge-primary{% else %}badge-outline{% endif %}">
+            Todos
+        </a>
         {% for value, label in statuses %}
             <a href="{% url 'certifications:my_certificates' %}?status={{ value }}"
-               class="tab {% if current_status == value %}tab-active{% endif %}">{{ label }}</a>
+               class="badge badge-lg cursor-pointer {% if current_status == value %}badge-primary{% else %}badge-outline{% endif %}">
+                {{ label }}
+            </a>
         {% endfor %}
     </div>
-    <!-- Certificates Grid -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {% for certificate in certificates %}
-            <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
-                <!-- Certificate Header -->
-                <div class="h-32 bg-gradient-to-br from-primary to-secondary flex items-center justify-center relative">
-                    {% if certificate.status == 'issued' %}
-                        <svg class="w-16 h-16 text-white opacity-80"
-                             fill="none"
-                             stroke="currentColor"
-                             viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-                        </svg>
-                    {% elif certificate.status == 'revoked' %}
-                        <svg class="w-16 h-16 text-white opacity-50"
-                             fill="none"
-                             stroke="currentColor"
-                             viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
-                        </svg>
-                    {% endif %}
-                    <!-- Status Badge -->
-                    <div class="absolute top-2 right-2">
-                        <span class="badge {% if certificate.status == 'issued' %}badge-success {% elif certificate.status == 'revoked' %}badge-error {% elif certificate.status == 'expired' %}badge-warning {% else %}badge-ghost{% endif %}">
-                            {{ certificate.get_status_display }}
-                        </span>
+
+    {% if certificates %}
+        <!-- Certificates Grid -->
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {% for certificate in certificates %}
+                <div class="card bg-white dark:bg-gray-800 shadow-md hover:shadow-xl transition-shadow border border-gray-100 dark:border-gray-700">
+                    <!-- Header -->
+                    <div class="card-body p-5">
+                        <div class="flex items-start justify-between gap-3 mb-3">
+                            <div class="flex-1 min-w-0">
+                                <h3 class="font-semibold text-lg text-gray-900 dark:text-white truncate"
+                                    title="{{ certificate.course.title }}">
+                                    {{ certificate.course.title }}
+                                </h3>
+                                <p class="text-xs text-gray-500 dark:text-gray-400 font-mono mt-1 break-all">
+                                    {{ certificate.certificate_number }}
+                                </p>
+                            </div>
+                            <!-- PDF icon -->
+                            <div class="flex-shrink-0">
+                                <svg xmlns="http://www.w3.org/2000/svg"
+                                     class="w-10 h-10 text-primary-500"
+                                     fill="none"
+                                     viewBox="0 0 24 24"
+                                     stroke="currentColor"
+                                     stroke-width="1.5">
+                                    <path stroke-linecap="round"
+                                          stroke-linejoin="round"
+                                          d="M9 12h6m-6 4h6m-6-8h2M9 2h6l5 5v13a2 2 0 01-2 2H9a2 2 0 01-2-2V4a2 2 0 012-2z" />
+                                </svg>
+                            </div>
+                        </div>
+
+                        <!-- Status badge -->
+                        <div class="mb-3">
+                            <span class="badge {% if certificate.status == 'issued' %}badge-success{% elif certificate.status == 'expired' %}badge-warning{% elif certificate.status == 'revoked' %}badge-error{% else %}badge-info{% endif %}">
+                                {{ certificate.get_status_display }}
+                            </span>
+                        </div>
+
+                        <!-- Details -->
+                        <div class="space-y-1 text-sm">
+                            {% if certificate.issued_at %}
+                                <div class="flex justify-between">
+                                    <span class="text-gray-500 dark:text-gray-400">Emitido</span>
+                                    <span class="text-gray-900 dark:text-white">
+                                        {{ certificate.issued_at|date:"d M Y" }}
+                                    </span>
+                                </div>
+                            {% endif %}
+                            {% if certificate.expires_at %}
+                                <div class="flex justify-between">
+                                    <span class="text-gray-500 dark:text-gray-400">Vence</span>
+                                    <span class="text-gray-900 dark:text-white">
+                                        {{ certificate.expires_at|date:"d M Y" }}
+                                    </span>
+                                </div>
+                            {% endif %}
+                            {% if certificate.score %}
+                                <div class="flex justify-between">
+                                    <span class="text-gray-500 dark:text-gray-400">Puntaje</span>
+                                    <span class="font-semibold text-gray-900 dark:text-white">
+                                        {{ certificate.score|floatformat:0 }}%
+                                    </span>
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <!-- Actions -->
+                        <div class="card-actions justify-end mt-4 flex-wrap gap-2">
+                            <a href="{% url 'certifications:detail' certificate.id %}"
+                               class="btn btn-sm btn-ghost">
+                                Ver detalle
+                            </a>
+                            {% if certificate.certificate_file and certificate.status == 'issued' %}
+                                <a href="{% url 'certifications:download' certificate.id %}"
+                                   class="btn btn-sm btn-primary">
+                                    <svg xmlns="http://www.w3.org/2000/svg"
+                                         class="w-4 h-4 mr-1"
+                                         fill="none"
+                                         viewBox="0 0 24 24"
+                                         stroke="currentColor"
+                                         stroke-width="2">
+                                        <path stroke-linecap="round"
+                                              stroke-linejoin="round"
+                                              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                    </svg>
+                                    Descargar PDF
+                                </a>
+                            {% endif %}
+                            {% if certificate.verification_url %}
+                                <button type="button"
+                                        class="btn btn-sm btn-outline"
+                                        x-data="{ copied: false }"
+                                        @click="navigator.clipboard.writeText('{{ certificate.verification_url|escapejs }}'); copied = true; setTimeout(() => copied = false, 2000)"
+                                        :class="{ 'btn-success': copied }">
+                                    <span x-show="!copied">Compartir verificación</span>
+                                    <span x-show="copied" x-cloak>¡Copiado!</span>
+                                </button>
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
-                <div class="p-4">
-                    <!-- Course Title -->
-                    <h3 class="font-semibold text-gray-900 dark:text-white mb-1">{{ certificate.course.title }}</h3>
-                    <!-- Certificate Number -->
-                    <p class="text-sm text-gray-500 dark:text-gray-400 font-mono mb-3">{{ certificate.certificate_number }}</p>
-                    <!-- Details -->
-                    <div class="space-y-2 text-sm">
-                        {% if certificate.issued_at %}
-                            <div class="flex justify-between">
-                                <span class="text-gray-500 dark:text-gray-400">Emitido</span>
-                                <span class="text-gray-900 dark:text-white">{{ certificate.issued_at|date:"d M Y" }}</span>
-                            </div>
-                        {% endif %}
-                        {% if certificate.expires_at %}
-                            <div class="flex justify-between">
-                                <span class="text-gray-500 dark:text-gray-400">Vence</span>
-                                <span class="{% if certificate.expires_at < now %}text-error{% else %}text-gray-900 dark:text-white{% endif %}">
-                                    {{ certificate.expires_at|date:"d M Y" }}
-                                </span>
-                            </div>
-                        {% endif %}
-                        {% if certificate.score %}
-                            <div class="flex justify-between">
-                                <span class="text-gray-500 dark:text-gray-400">Puntaje</span>
-                                <span class="text-gray-900 dark:text-white font-medium">{{ certificate.score|floatformat:0 }}%</span>
-                            </div>
-                        {% endif %}
-                    </div>
-                    <!-- Actions -->
-                    <div class="mt-4 flex gap-2">
-                        <a href="{% url 'certifications:detail' certificate.id %}"
-                           class="btn btn-ghost btn-sm flex-1">Ver Detalles</a>
-                        {% if certificate.certificate_file %}
-                            <a href="{% url 'certifications:download' certificate.id %}"
-                               class="btn btn-primary btn-sm flex-1">Descargar</a>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        {% empty %}
-            <div class="col-span-full text-center py-12">
-                <svg class="mx-auto h-12 w-12 text-gray-400"
+            {% endfor %}
+        </div>
+    {% else %}
+        <!-- Empty state -->
+        <div class="card bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700">
+            <div class="card-body items-center text-center py-16">
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     class="w-16 h-16 text-gray-400 mb-4"
                      fill="none"
+                     viewBox="0 0 24 24"
                      stroke="currentColor"
-                     viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
+                     stroke-width="1.5">
+                    <path stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
                 </svg>
-                <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">No tienes certificados</h3>
-                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Completa cursos para obtener certificados.</p>
-                <div class="mt-6">
-                    <a href="{% url 'courses:list' %}" class="btn btn-primary">Ver Cursos</a>
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+                    {% if current_status %}
+                        No tienes certificados con este estado
+                    {% else %}
+                        Aún no tienes certificados
+                    {% endif %}
+                </h3>
+                <p class="text-sm text-gray-500 dark:text-gray-400 max-w-md">
+                    Inscríbete a un curso y complétalo al 100% para obtener tu primer certificado.
+                </p>
+                <div class="card-actions mt-4">
+                    <a href="{% url 'courses:list' %}" class="btn btn-primary">
+                        Explorar cursos
+                    </a>
                 </div>
             </div>
-        {% endfor %}
-    </div>
+        </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Resumen

Bloque `certificados` entregado vía /modulo. PR único con 4 sub-features + 1 scaffolding mergeadas en orden de dependencias topológicas.

Refs #43, Refs #44

## Estado pre-bloque

La app `apps/certifications/` ya tenía ~70% del módulo:
- Models: `CertificateTemplate`, `Certificate`, `CertificateVerification`
- `CertificateService` con ciclo completo (issue/revoke/reissue/verify/expire)
- 4 views web + API REST + Django admin
- Templates HTML iniciales

**Gaps que cubre este PR:**
1. Dependencias PDF NO instaladas → `_generate_pdf` caía a placeholder 176 bytes
2. Sin signal automático → cliente debía emitir manual
3. Sin panel UI para parametrizar plantilla (solo Django admin)
4. Template HTML default ausente
5. Descarga vía `HttpResponseRedirect` a GCS URL (frágil)

## Sub-features

| Branch | Sub-feature | Issue refs |
|---|---|---|
| B0 / `78a3a0f` | Scaffolding: deps PDF + `Dockerfile` libpango + `certificate_template.html` (diseño cliente) + stubs signals/forms | #43, #44 |
| B1 / `7d02d15` | Signal `post_save` Enrollment → `CertificateService.issue_certificate` (idempotente, `transaction.on_commit`) + 4 tests | #43 |
| B2 / `8d4038b` | Panel UI custom `CertificateTemplate`: ModelForm + 5 views (list/create/edit/preview/toggle) + 4 templates + 12 tests | #44 |
| B3 / `e18855d` | `certificate_download` → `FileResponse` (streaming PDF, sin GCS public URL) + `my_certificates.html`/`certificate_detail.html` rediseñadas + 8 tests | #43 |
| B4 / `1dc17be` | Tests E2E acceptance: template → enroll → COMPLETED → cert ISSUED → download (2 cases) | #43, #44 |

## Tests

| Módulo | Cases |
|---|---|
| test_signals.py | 4 |
| test_admin_views.py | 12 |
| test_download.py | 8 |
| test_e2e.py | 2 |
| **Total nuevos** | **26** |

Auto-verificación local: ast-parse OK en los 8 archivos `.py` modificados/creados. Suite Django pendiente de validar en CI (no hay venv local en el worktree). El deploy CI de SD corre la suite.

## Cambios en infra

- `requirements/base.txt`: + `weasyprint>=62.0,<63`, + `qrcode[pil]>=7.4,<8`, + `reportlab>=4.2,<5`
- `Dockerfile` runtime stage: + `libpango-1.0-0 libpangoft2-1.0-0 libcairo-gobject2 libgdk-pixbuf-2.0-0 shared-mime-info` (deps weasyprint)

## Conflict resuelto

`apps/certifications/views.py` — B2 (5 views nuevas al final con imports) vs B3 (cambio en `certificate_download` + import `FileResponse`). Resolución manual: B3 va dentro de `certificate_download`, B2 al final. Validado con ast-parse.

## Smoke pendiente

F6 corre post-merge vía `/qa-prod`. Plan E2E:
1. Login qa_claude → enroll a curso → completar lecciones → ver cert en `/certificates/`
2. Descargar PDF → assert mime + size > 10KB
3. `/certificates/verify/<num>/` devuelve "valid"
4. Login staff → `/certificates/admin/templates/` → editar template, subir firma → preview render OK

## NO usar Closes

Los issues #43 y #44 quedan abiertos. F7 asigna a `anasofiamc1-cpu` (validadora SD) con comentario individual. La validadora cierra tras validar funcionalmente.

🤖 Generado vía /modulo (RUN_2026-05-28_0926)