### PR TITLE
ci(deploy): build en GitHub-hosted x86 nativo (sin QEMU) — Sprint 3B ola 2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   deploy:
     name: Build and Deploy
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Ola 2 de la migración (solicitada por Miguel): build amd64 **nativo** en `ubuntu-latest` en vez de QEMU sobre Colima ARM (~14 min → ~4-6 min; elimina el OOM intermitente #19 y libera el runner de la mini). Cache: `/Volumes` → `type=gha` donde aplicaba; `type=registry` (Coditeq) se mantiene. Secrets/gcloud/migraciones: sin cambios.

**Verificado post-push:** sha256 remoto == local, sin `self-hosted`, sin `/Volumes`, sin binfmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCDuquYJpFXvZcwwngY3rH