### PR TITLE
Certificados: indicador de generación pendiente + fix comentario Django [#43]

### DIFF
--- a/apps/certifications/tests/test_admin_views.py
+++ b/apps/certifications/tests/test_admin_views.py
@@ -10,6 +10,7 @@ Covers:
 
 from datetime import date
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import reverse
 
@@ -48,6 +49,11 @@ class _BaseAdminViewsTests(TestCase):
         self.template = CertificateTemplate.objects.create(
             name="Plantilla Demo",
             description="Plantilla para tests",
+            template_file=SimpleUploadedFile(
+                "plantilla_demo.html",
+                b"<html><body>CERTIFICADO - {{ user_name }}</body></html>",
+                content_type="text/html",
+            ),
             signer_name="Directora HSEQ",
             signer_title="Directora",
             is_active=True,
@@ -97,6 +103,9 @@ class TemplateCreateTests(_BaseAdminViewsTests):
             data={
                 "name": "Plantilla Nueva",
                 "description": "Creada en test",
+                "template_file": SimpleUploadedFile(
+                    "plantilla_nueva.html", b"<html></html>", content_type="text/html"
+                ),
                 "signer_name": "Firma X",
                 "signer_title": "Cargo Y",
                 "is_active": "on",

--- a/apps/certifications/tests/test_e2e.py
+++ b/apps/certifications/tests/test_e2e.py
@@ -16,6 +16,7 @@ from datetime import date
 from unittest.mock import patch
 
 from django.core.files.base import ContentFile
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TransactionTestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -113,6 +114,9 @@ class CertificadosE2ETest(TransactionTestCase):
             data={
                 "name": "Plantilla E2E",
                 "description": "Plantilla para test E2E",
+                "template_file": SimpleUploadedFile(
+                    "plantilla_e2e.html", b"<html></html>", content_type="text/html"
+                ),
                 "signer_name": "Directora HSEQ",
                 "signer_title": "HSEQ",
                 "is_active": "on",

--- a/apps/certifications/tests/test_issue_43.py
+++ b/apps/certifications/tests/test_issue_43.py
@@ -22,9 +22,11 @@ B2 (Course.duration_hours) is covered separately in
 apps/courses/tests/test_issue_43.py since it's a Course model concern.
 """
 
+import re
 from datetime import date, timedelta
 from unittest.mock import patch
 
+from django.core.files.base import ContentFile
 from django.test import TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -405,4 +407,144 @@ class ReassignEnrollmentViewReissueTest(TransactionTestCase):
         self.assertTrue(
             certs.filter(status=Certificate.Status.ISSUED).exists(),
             "expected a fresh ISSUED certificate after recompletion post-reassignment",
+        )
+
+
+# Minimal valid PDF content, same pattern used by test_download.py, to give
+# the older ("still visible/downloadable") certificate a real attached file —
+# without it the pre-existing template gate
+# (`certificate.certificate_file and certificate.status == 'issued'`) hides
+# the download link regardless of status, which isn't the scenario SD#43
+# describes (the OLD cert is a real, already-downloadable certificate).
+MINIMAL_PDF = b"%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF\n"
+
+# Matches the pending-notice <div ...> ONLY as an HTML tag attribute — not the
+# always-present `[data-certificate-pending="true"]` CSS selector string
+# embedded in the auto-refresh <script> (see extra_js block), which would
+# otherwise produce a false positive on a plain substring check.
+PENDING_MARKER_TAG_RE = re.compile(r'<div[^>]*\bdata-certificate-pending="true"[^>]*>')
+
+
+@override_settings(
+    STORAGES={
+        "default": {"BACKEND": "django.core.files.storage.InMemoryStorage"},
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
+        },
+    },
+)
+class MyCertificatesPendingIndicatorTest(TestCase):
+    """
+    UX mitigation (F2/F3, SD#43 reproceso round 2): F2 REFUTED F1's silent-
+    rollback hypothesis with hard evidence (psql against prod, 48h Cloud Run
+    logs, live HTTP download+pdftotext of 2 real certificates) — the
+    generation pipeline works correctly end to end. The most plausible
+    explanation for what the client saw is a ~3.5s timing window between
+    Enrollment.completed_at and Certificate.status flipping to 'issued'
+    (transaction.on_commit + weasyprint render), during which the NEW
+    certificate exists with status=PENDING (no download button, template
+    gates on status=='issued') while an OLDER certificate from a different
+    course remains fully visible/downloadable on the same page with no
+    indicator explaining the missing new one.
+
+    These tests cover the UX mitigation only (explicit pending notice +
+    bounded auto-refresh marker in my_certificates.html) — they do not (and
+    cannot) reproduce the transitory timing window itself.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="user-issue43-pending@test.com",
+            password="testpass123",
+            first_name="Marta",
+            last_name="Lopez",
+            document_number="900000401",
+            job_position="Technician",
+            hire_date=date(2021, 6, 15),
+        )
+        self.old_course = Course.objects.create(
+            code="ISSUE43-PEND-OLD",
+            title="Curso Viejo Issue 43",
+            created_by=self.user,
+            status=Course.Status.PUBLISHED,
+            validity_months=12,
+        )
+        self.new_course = Course.objects.create(
+            code="ISSUE43-PEND-NEW",
+            title="Curso Nuevo Issue 43",
+            created_by=self.user,
+            status=Course.Status.PUBLISHED,
+            validity_months=12,
+        )
+        # Older certificate, fully issued AND with a real file attached, so
+        # it renders as downloadable — mirrors the real prod case (user_id=2
+        # had an ISSUED+downloadable certificate for course 63 while course
+        # 68's certificate was still generating).
+        self.old_cert = Certificate.objects.create(
+            user=self.user,
+            course=self.old_course,
+            certificate_number="SD-ISSUE43-PEND-OLD",
+            status=Certificate.Status.ISSUED,
+            issued_at=timezone.now() - timedelta(days=20),
+            expires_at=timezone.now() + timedelta(days=345),
+        )
+        self.old_cert.certificate_file.save(
+            f"{self.old_cert.certificate_number}.pdf",
+            ContentFile(MINIMAL_PDF),
+            save=True,
+        )
+
+    def test_pending_certificate_shows_generation_notice_and_poll_marker(self):
+        """
+        While the new certificate is still PENDING, the card must show an
+        explicit notice and the pending-marker tag must render, instead of
+        silently omitting the download button with no explanation — and the
+        older certificate's download link must remain untouched (still
+        visible), matching the real scenario.
+        """
+        new_cert = Certificate.objects.create(
+            user=self.user,
+            course=self.new_course,
+            certificate_number="SD-ISSUE43-PEND-NEW",
+            status=Certificate.Status.PENDING,
+        )
+
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("certifications:my_certificates"))
+        content = response.content.decode()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Certificado en generación")
+        self.assertRegex(content, PENDING_MARKER_TAG_RE)
+        # Bounded auto-refresh marker present (script only acts when the
+        # pending-marker tag it queries for actually exists in the DOM).
+        self.assertContains(response, "sd43CertPollStart")
+        # The older certificate keeps its download link...
+        self.assertContains(
+            response, reverse("certifications:download", args=[self.old_cert.id])
+        )
+        # ...but the new PENDING certificate must not offer one yet.
+        self.assertNotContains(
+            response, reverse("certifications:download", args=[new_cert.id])
+        )
+
+    def test_no_pending_certificates_omits_notice_and_marker_tag(self):
+        """
+        Baseline / regression guard: with no PENDING certificate (only the
+        older ISSUED+downloadable one from setUp), neither the notice nor the
+        pending-marker tag should render on any card — the auto-refresh
+        script itself may still be present in the page (it self-gates via a
+        DOM query and is a no-op with nothing to find), but it must find
+        zero elements to act on.
+        """
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("certifications:my_certificates"))
+        content = response.content.decode()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Certificado en generación")
+        self.assertNotRegex(content, PENDING_MARKER_TAG_RE)
+        # The older certificate's download link is present and untouched.
+        self.assertContains(
+            response, reverse("certifications:download", args=[self.old_cert.id])
         )

--- a/templates/certifications/my_certificates.html
+++ b/templates/certifications/my_certificates.html
@@ -63,6 +63,18 @@
                             </span>
                         </div>
 
+                        {% if certificate.status == 'pending' %}
+                            <!-- Pending generation notice (SD#43): the download button only
+                                 appears once status flips to 'issued' (a few seconds after
+                                 course completion, while the PDF renders). Without this
+                                 notice a user could mistake a still-visible OLDER certificate
+                                 for the new one. -->
+                            <div class="alert alert-info text-xs py-2 px-3 mb-3"
+                                 data-certificate-pending="true">
+                                <span>Certificado en generación, actualiza en unos segundos.</span>
+                            </div>
+                        {% endif %}
+
                         <!-- Details -->
                         <div class="space-y-1 text-sm">
                             {% if certificate.issued_at %}
@@ -160,4 +172,41 @@
             </div>
         </div>
     {% endif %}
+{% endblock %}
+
+{% block extra_js %}
+    {# SD#43: while any certificate is 'pending' (created but not yet issued —
+       transaction.on_commit + PDF render take a few seconds), poll lightly so
+       the "Descargar PDF" button appears without the user manually reloading.
+       Bounded to ~15s total (persisted across reloads via sessionStorage) so
+       it never polls forever if generation stalls. #}
+    <script nonce="{{ request.csp_nonce }}">
+        (function () {
+            var STORAGE_KEY = 'sd43CertPollStart';
+            var POLL_INTERVAL_MS = 2000;
+            var POLL_MAX_MS = 15000;
+
+            var hasPending = document.querySelector('[data-certificate-pending="true"]') !== null;
+            if (!hasPending) {
+                sessionStorage.removeItem(STORAGE_KEY);
+                return;
+            }
+
+            var now = Date.now();
+            var start = parseInt(sessionStorage.getItem(STORAGE_KEY), 10);
+            if (!start) {
+                start = now;
+                sessionStorage.setItem(STORAGE_KEY, String(start));
+            }
+
+            if (now - start >= POLL_MAX_MS) {
+                sessionStorage.removeItem(STORAGE_KEY);
+                return;
+            }
+
+            setTimeout(function () {
+                window.location.reload();
+            }, POLL_INTERVAL_MS);
+        })();
+    </script>
 {% endblock %}

--- a/templates/certifications/my_certificates.html
+++ b/templates/certifications/my_certificates.html
@@ -175,11 +175,13 @@
 {% endblock %}
 
 {% block extra_js %}
-    {# SD#43: while any certificate is 'pending' (created but not yet issued —
-       transaction.on_commit + PDF render take a few seconds), poll lightly so
-       the "Descargar PDF" button appears without the user manually reloading.
-       Bounded to ~15s total (persisted across reloads via sessionStorage) so
-       it never polls forever if generation stalls. #}
+    {% comment %}
+    SD#43: while any certificate is 'pending' (created but not yet issued —
+    transaction.on_commit + PDF render take a few seconds), poll lightly so
+    the "Descargar PDF" button appears without the user manually reloading.
+    Bounded to ~15s total (persisted across reloads via sessionStorage) so
+    it never polls forever if generation stalls.
+    {% endcomment %}
     <script nonce="{{ request.csp_nonce }}">
         (function () {
             var STORAGE_KEY = 'sd43CertPollStart';

--- a/templates/certifications/not_authorized.html
+++ b/templates/certifications/not_authorized.html
@@ -1,0 +1,20 @@
+{% extends "base/dashboard.html" %}
+{% block content %}
+    <div class="min-h-screen bg-gray-50 dark:bg-gray-900 py-12">
+        <div class="max-w-lg mx-auto px-4">
+            <div class="text-center mb-8">
+                <svg class="mx-auto w-16 h-16 text-error"
+                     fill="none"
+                     stroke="currentColor"
+                     viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                </svg>
+                <h1 class="mt-4 text-2xl font-bold text-gray-900 dark:text-white">No autorizado</h1>
+                <p class="mt-2 text-gray-600 dark:text-gray-400">No tienes permiso para descargar este certificado.</p>
+            </div>
+            <div class="text-center">
+                <a href="{% url 'certifications:my_certificates' %}" class="btn btn-primary">Volver a Mis Certificados</a>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/certifications/not_available.html
+++ b/templates/certifications/not_available.html
@@ -1,0 +1,20 @@
+{% extends "base/dashboard.html" %}
+{% block content %}
+    <div class="min-h-screen bg-gray-50 dark:bg-gray-900 py-12">
+        <div class="max-w-lg mx-auto px-4">
+            <div class="text-center mb-8">
+                <svg class="mx-auto w-16 h-16 text-warning"
+                     fill="none"
+                     stroke="currentColor"
+                     viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                <h1 class="mt-4 text-2xl font-bold text-gray-900 dark:text-white">Certificado no disponible</h1>
+                <p class="mt-2 text-gray-600 dark:text-gray-400">{{ message }}</p>
+            </div>
+            <div class="text-center">
+                <a href="{% url 'certifications:my_certificates' %}" class="btn btn-primary">Volver a Mis Certificados</a>
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Refs #43 — fix autónomo; **quedó en PR draft por falso positivo del deploy_gate (revisar y deployar vos).**

## Resumen

Reproceso (bounce=2, categoría previa FIX_INCOMPLETO). El diagnóstico adversarial de F2 REFUTÓ la hipótesis inicial (excepción silenciosa/rollback en la generación del certificado) con evidencia dura: psql contra prod, 48h de logs Cloud Run, y descarga HTTP en vivo de 2 certificados reales — el pipeline de generación funciona correctamente. La explicación más plausible: ventana async de ~3.5s entre `Enrollment.completed_at` y que el certificado quede `status=issued`, durante la cual el certificado nuevo existe como PENDING (sin botón de descarga) mientras el viejo de otro curso sigue 100% visible/descargable.

## Fix (bajo riesgo, sin migración, sin BD)

- `templates/certifications/my_certificates.html`: indicador "Certificado en generación" en cards con `status=pending` + auto-refresh acotado (~15s, sessionStorage) para que el botón de descarga aparezca solo.
- **Bonus (deuda pre-existente NO relacionada, detectada por el gate de self-verify):** faltaban los templates `not_available.html` y `not_authorized.html` que `certificate_download()` referenciaba — bug real de producción (500 para certificados expirados/revocados/no autorizados). Se agregaron + se corrigieron 2 tests que posteaban sin el archivo requerido del formulario de plantilla (`chore/sd-certifications-test-debt`, mergeado a esta branch).
- Fix de un comentario Django `{# #}` multilínea que se renderizaba literal en prod (Django solo soporta una línea).

## Por qué quedó en HOLD (falso positivo)

El gate `deploy_gate.py` detectó mecánicamente la palabra "psql" dentro de un **docstring** de `apps/certifications/tests/test_issue_43.py` (documentando en prosa que F2 usó psql contra prod DURANTE EL DIAGNÓSTICO, no que el test lo ejecuta). Verificado manualmente: `grep -n psql apps/certifications/tests/test_issue_43.py` → única aparición es texto narrativo en un docstring de clase, no código ejecutable. Es la misma clase de falso positivo que bloqueó a #48 en este mismo RUN (palabra "RunPython" en un comentario). Dejado en HOLD por diseño safe-by-default de `--unattended`.

## Verificación local

- 71/71 tests passed en `apps/certifications` (incluye los 2 nuevos de `test_issue_43.py` + la deuda pre-existente ya reparada).
- `f3_selfverify.sh`: 5/5 checks OK.
- Journey E2E `SD_43.yaml` (read-only, usa 2 certificados reales existentes) pre-linteado OK, pendiente correr post-deploy.

## Para deployar

1. Revisar el diff (templates + 2 archivos de test).
2. Mergear o disparar deploy manual del branch `fix/sd-43`.
3. Correr smoke/E2E contra "Mis Certificados".

🤖 Generado por mbrt26 vía sistema multiagente (RUN_2026-07-02_0223).