### PR TITLE
fix: resolver 3 fallas preexistentes de la suite completa

### DIFF
--- a/apps/inspections/tests/test_models.py
+++ b/apps/inspections/tests/test_models.py
@@ -64,7 +64,8 @@ class InspectionTestCase(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            email="inspector@test.com", password="password", first_name="Inspector"
+            email="inspector@test.com", password="password", first_name="Inspector",
+            hire_date=date(2020, 1, 1),
         )
         self.category = EquipmentCategory.objects.create(name="Excavadoras")
         self.equipment = Equipment.objects.create(
@@ -101,7 +102,8 @@ class FindingTestCase(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            email="inspector@test.com", password="password", first_name="Inspector"
+            email="inspector@test.com", password="password", first_name="Inspector",
+            hire_date=date(2020, 1, 1),
         )
         self.category = EquipmentCategory.objects.create(name="Excavadoras")
         self.equipment = Equipment.objects.create(
@@ -133,9 +135,13 @@ class CorrectiveActionTestCase(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            email="inspector@test.com", password="password", first_name="Inspector"
+            email="inspector@test.com", password="password", first_name="Inspector",
+            hire_date=date(2020, 1, 1), document_number="900000001",
         )
-        self.responsible = User.objects.create_user("responsible", "resp@test.com", "password")
+        self.responsible = User.objects.create_user(
+            email="resp@test.com", password="password", first_name="Responsible",
+            hire_date=date(2020, 1, 1), document_number="900000002",
+        )
         self.category = EquipmentCategory.objects.create(name="Excavadoras")
         self.equipment = Equipment.objects.create(
             folio="EXC-001",

--- a/apps/learning_paths/models.py
+++ b/apps/learning_paths/models.py
@@ -80,13 +80,16 @@ class LearningPath(models.Model):
 
     @property
     def total_duration(self):
-        """Calculate total duration from all courses (in minutes)."""
-        from django.db.models import F, Sum
+        """Calculate total duration from all courses (in minutes).
 
-        result = self.path_courses.aggregate(
-            total=Sum(F("course__total_duration"), output_field=models.IntegerField())
+        `Course.total_duration` is itself a Python `@property` (aggregates
+        lesson durations), not a DB field/annotation — an `F()`/`Sum()`
+        aggregate can't traverse it, so this sums in Python instead.
+        """
+        return sum(
+            pc.course.total_duration
+            for pc in self.path_courses.select_related("course")
         )
-        return result["total"] or 0
 
 
 class PathCourse(models.Model):

--- a/apps/sync/tests/factories.py
+++ b/apps/sync/tests/factories.py
@@ -14,6 +14,7 @@ import factory
 from factory.django import DjangoModelFactory
 
 from apps.courses.models import Course
+from apps.courses.tests.factories import JobProfileTypeFactory
 from apps.sync.models import (
     OfflinePackage,
     PackageDownload,
@@ -38,7 +39,7 @@ class UserFactory(DjangoModelFactory):
     document_type = "CC"
     document_number = factory.Sequence(lambda n: f"{50000000 + n}")
     job_position = "Technician"
-    job_profile = "LINIERO"
+    job_profile = factory.SubFactory(JobProfileTypeFactory)
     hire_date = factory.LazyFunction(lambda: date.today() - timedelta(days=365))
     is_active = True
 


### PR DESCRIPTION
Fix autónomo (pedido explícito de Miguel: "¿En SD podemos resolver las fallas preexistentes?"), NO ligado a ningún issue del cliente — desbloquea el gate `f3_selfverify.sh` de SD#62/SD#63, que escaló a full-repo por tocar `urls.py` y encontró estas 125 fallas/67 errores ajenos.

## Root causes (3, independientes)

1. **`LearningPath.total_duration`** (`apps/learning_paths/models.py`) usaba `Sum(F("course__total_duration"))`, pero `Course.total_duration` es una `@property` Python (agrega `lesson.duration` en memoria), no un campo/annotation de BD — `F()` no puede atravesar una property. Reescrito para sumar en Python iterando `path_courses`.
2. **`apps/sync` `UserFactory`** asignaba `job_profile="LINIERO"` (string plano) a un `ForeignKey(JobProfileType)`. Ahora usa `factory.SubFactory(JobProfileTypeFactory)`, igual que la factory canónica de `apps.courses.tests.factories`.
3. **`apps/inspections/tests/test_models.py`** llamaba `User.objects.create_user()` sin `hire_date` (NOT NULL, sin default) y con `document_number` sin especificar en 2 usuarios del mismo `setUp` (unique=True, ambos caían en `""` y colisionaban).

## Evidencia

Suite completa (`pytest`, sin cobertura): **125 failed / 67 errors → 1351 passed, 0 failed, 1 skipped**.

Sin migraciones, sin cambios de comportamiento en código de producción salvo el fix real de `total_duration` (que corrige un valor mal calculado, no introduce lógica nueva).