### PR TITLE
Bundle bugs SD: #75 notificaciones nunca creadas + #76 CSP no emitido en prod (Refs)

### DIFF
--- a/apps/core/tests/test_issue_76.py
+++ b/apps/core/tests/test_issue_76.py
@@ -1,0 +1,305 @@
+"""
+Tests SD#76 -- el header de CSP se EMITE con el settings que corre en produccion.
+
+Por que estos tests y no otros
+------------------------------
+El bug de #76 no era "la constante esta mal escrita": era que NADIE ejercitaba
+el camino real. La CSP estaba declarada en `config/settings/production.py`, un
+modulo que produccion no carga (deploy.yml despliega Cloud Run con
+DJANGO_SETTINGS_MODULE=config.settings.cloudrun), y encima en el formato plano
+CSP_* que django-csp 4.0 ignora en silencio. Un test que solo mirara "existe
+CSP_SCRIPT_SRC en el archivo" habria pasado en verde con cero header en prod.
+
+Ademas `config/settings/test.py` saca a proposito el CSPMiddleware del
+MIDDLEWARE ("avoids django-csp version conflicts"), asi que la suite por
+defecto nunca podia ver el header. Por eso aca:
+
+  1. Se importa DE VERDAD el modulo de settings que despliega deploy.yml
+     (no se copian los valores a mano).
+  2. Se corre el CSPMiddleware real con esa configuracion y se afirma sobre el
+     header de la respuesta, no sobre la constante.
+  3. Se cubre tambien el request end-to-end por el stack de middleware de prod.
+
+NOTA: a proposito NO se importa `config.settings.production` aca. Ese modulo
+hace `INSTALLED_APPS += ["cachalot"]`, que muta in-place la lista compartida
+con `config.settings.base` y contaminaria el resto de la suite. Para production
+se valida a nivel de fuente (test_production_settings_migrado).
+"""
+
+import importlib
+import os
+import re
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+
+from csp.checks import OUTDATED_SETTINGS
+from csp.constants import HEADER, HEADER_REPORT_ONLY
+from csp.middleware import CSPMiddleware
+
+# El modulo que deploy.yml pasa como DJANGO_SETTINGS_MODULE al desplegar
+# Cloud Run (y a los jobs de migrate / ensure_admin / axes_reset).
+PROD_SETTINGS_MODULE = "config.settings.cloudrun"
+
+# Minimo para poder importar el settings de Cloud Run fuera de Cloud Run:
+# cloudrun.py resuelve config("DB_PASSWORD") sin default al importarse.
+_REQUIRED_ENV = {"DB_PASSWORD": "solo-para-tests"}
+
+
+@contextmanager
+def load_prod_settings(**extra_env):
+    """Importa de verdad el modulo de settings que corre en produccion.
+
+    Se importa como modulo (no se activa como settings de Django) para poder
+    leer sus valores reales sin tocar la configuracion viva de la suite.
+    """
+    env = {**_REQUIRED_ENV, **extra_env}
+    previous = {key: os.environ.get(key) for key in env}
+    os.environ.update(env)
+    sys.modules.pop(PROD_SETTINGS_MODULE, None)
+    try:
+        yield importlib.import_module(PROD_SETTINGS_MODULE)
+    finally:
+        sys.modules.pop(PROD_SETTINGS_MODULE, None)
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def run_middleware(**settings_overrides):
+    """Corre el CSPMiddleware real sobre una respuesta cualquiera."""
+    with override_settings(**settings_overrides):
+        middleware = CSPMiddleware(lambda request: HttpResponse("ok"))
+        return middleware(RequestFactory().get("/"))
+
+
+class ProdSettingsDefineCSPTests(SimpleTestCase):
+    """El settings que realmente corre en prod define la politica (fact #1)."""
+
+    def test_cloudrun_define_la_politica_en_formato_django_csp_4(self):
+        with load_prod_settings() as prod:
+            # Default = report-only: emite y reporta, no bloquea.
+            self.assertTrue(
+                hasattr(prod, "CONTENT_SECURITY_POLICY_REPORT_ONLY"),
+                "config.settings.cloudrun no define CONTENT_SECURITY_POLICY_REPORT_ONLY; "
+                "produccion volveria a quedarse sin header (SD#76).",
+            )
+            policy = prod.CONTENT_SECURITY_POLICY_REPORT_ONLY
+            self.assertIn("DIRECTIVES", policy)
+            self.assertIn("default-src", policy["DIRECTIVES"])
+
+    def test_cloudrun_no_conserva_settings_planos_csp_legacy(self):
+        """Las CSP_* planas son ignoradas en silencio por django-csp 4.0."""
+        with load_prod_settings() as prod:
+            sobrevivientes = [name for name in OUTDATED_SETTINGS if hasattr(prod, name)]
+            self.assertEqual(
+                sobrevivientes,
+                [],
+                f"Settings CSP legacy en {PROD_SETTINGS_MODULE}: {sobrevivientes}. "
+                "django-csp 4.0 no las lee para construir la politica (solo dispara "
+                "el check csp.E001).",
+            )
+
+    def test_csp_enforce_no_colisiona_con_el_namespace_legacy(self):
+        """Guarda: si una version futura reclama CSP_ENFORCE, que salte aca."""
+        self.assertNotIn("CSP_ENFORCE", OUTDATED_SETTINGS)
+
+    def test_app_csp_instalada_para_que_sus_checks_se_registren(self):
+        """Tercera capa de silencio de SD#76.
+
+        Los checks de django-csp (csp.E001 "estas usando settings < 4.0") se
+        registran desde csp/apps.py. Sin "csp" en INSTALLED_APPS el formato
+        viejo no producia NI header NI aviso. Con la app instalada, volver al
+        formato plano rompe `manage.py check`.
+        """
+        self.assertIn("csp", settings.INSTALLED_APPS)
+
+    def test_el_check_de_django_csp_detecta_el_formato_viejo(self):
+        from csp.checks import check_django_csp_lt_4_0
+
+        self.assertEqual(check_django_csp_lt_4_0(None), [])
+
+        with override_settings(CSP_DEFAULT_SRC=["'self'"]):
+            errores = check_django_csp_lt_4_0(None)
+        self.assertEqual([e.id for e in errores], ["csp.E001"])
+
+
+class CSPHeaderSeEmiteTests(SimpleTestCase):
+    """El header SALE. Este es el test que habria atrapado SD#76."""
+
+    def test_header_report_only_se_emite_con_la_politica_de_produccion(self):
+        with load_prod_settings() as prod:
+            policy = prod.CONTENT_SECURITY_POLICY_REPORT_ONLY
+
+        response = run_middleware(CONTENT_SECURITY_POLICY_REPORT_ONLY=policy)
+
+        self.assertIn(
+            HEADER_REPORT_ONLY,
+            response,
+            "El CSPMiddleware no emitio Content-Security-Policy-Report-Only con la "
+            "configuracion real de produccion.",
+        )
+        header = response[HEADER_REPORT_ONLY]
+        self.assertTrue(header.strip(), "El header salio vacio.")
+        self.assertIn("default-src 'self'", header)
+        # Arranca en report-only: NO debe salir el header bloqueante.
+        self.assertNotIn(HEADER, response)
+
+    def test_con_csp_enforce_el_header_pasa_a_bloqueante(self):
+        with load_prod_settings(CSP_ENFORCE="True") as prod:
+            self.assertTrue(
+                hasattr(prod, "CONTENT_SECURITY_POLICY"),
+                "Con CSP_ENFORCE=True cloudrun.py debe definir CONTENT_SECURITY_POLICY.",
+            )
+            self.assertFalse(hasattr(prod, "CONTENT_SECURITY_POLICY_REPORT_ONLY"))
+            policy = prod.CONTENT_SECURITY_POLICY
+
+        response = run_middleware(CONTENT_SECURITY_POLICY=policy)
+
+        self.assertIn(HEADER, response)
+        self.assertIn("default-src 'self'", response[HEADER])
+
+    def test_el_formato_viejo_csp_plano_NO_emite_header(self):
+        """Fija la causa raiz de SD#76: el formato < 4.0 se ignora en silencio."""
+        response = run_middleware(
+            CSP_DEFAULT_SRC=("'self'",),
+            CSP_SCRIPT_SRC=("'self'", "cdn.jsdelivr.net"),
+        )
+        self.assertNotIn(HEADER, response)
+        self.assertNotIn(HEADER_REPORT_ONLY, response)
+
+
+class CSPHeaderEnRequestRealTests(TestCase):
+    """End-to-end: request HTTP por el stack de middleware de produccion."""
+
+    def test_health_check_responde_con_el_header_csp(self):
+        with load_prod_settings() as prod:
+            prod_middleware = list(prod.MIDDLEWARE)
+            policy = prod.CONTENT_SECURITY_POLICY_REPORT_ONLY
+
+        self.assertIn(
+            "csp.middleware.CSPMiddleware",
+            prod_middleware,
+            "El MIDDLEWARE de produccion perdio el CSPMiddleware.",
+        )
+
+        with override_settings(
+            MIDDLEWARE=prod_middleware,
+            CONTENT_SECURITY_POLICY_REPORT_ONLY=policy,
+        ):
+            response = self.client.get("/health/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(HEADER_REPORT_ONLY, response)
+        self.assertIn("default-src 'self'", response[HEADER_REPORT_ONLY])
+
+
+class PoliticaCubreLosOrigenesRealesTests(SimpleTestCase):
+    """La politica se armo sobre los origenes que la app usa de verdad.
+
+    Cada afirmacion corresponde a evidencia concreta en templates. Si alguien
+    "endurece" la CSP sacando uno de estos, rompe una pantalla en produccion de
+    forma dificil de diagnosticar (no hay error de servidor, la pagina queda a
+    medias). Estos asserts son el recordatorio.
+    """
+
+    maxDiff = None
+
+    def setUp(self):
+        with load_prod_settings() as prod:
+            self.directives = prod.CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]
+
+    def test_script_src_cubre_los_cdn_con_script_tag(self):
+        script_src = self.directives["script-src"]
+        # base/base.html + feedback/base.html
+        self.assertIn("https://cdn.tailwindcss.com", script_src)
+        # alpinejs@3.x.x, echarts@5.5.0, sortablejs@1.15.0
+        self.assertIn("https://cdn.jsdelivr.net", script_src)
+        # htmx.org@1.9.11 / @1.9.12 + ext/loading-states
+        self.assertIn("https://unpkg.com", script_src)
+
+    def test_script_src_permite_eval_por_alpine_y_tailwind_cdn(self):
+        """Alpine evalua x-data/@click con new Function(); Tailwind CDN compila CSS."""
+        self.assertIn("'unsafe-eval'", self.directives["script-src"])
+
+    def test_script_src_no_mezcla_nonce_con_unsafe_inline(self):
+        """Un nonce hace que el navegador IGNORE 'unsafe-inline' en esa directiva.
+
+        Quedan 29 bloques <script> inline y solo 10 llevan nonce, asi que meter
+        el nonce hoy apagaria 'unsafe-inline' y romperia los otros 19 (portal
+        publico de tickets, dashboards con ECharts, firma de asistencia).
+        """
+        script_src = self.directives["script-src"]
+        self.assertIn("'unsafe-inline'", script_src)
+        self.assertFalse(
+            any("nonce" in str(value) for value in script_src),
+            "script-src mezcla nonce con 'unsafe-inline': el nonce gana y anula "
+            "el 'unsafe-inline' del que dependen los inline sin nonce.",
+        )
+
+    def test_style_src_permite_inline_por_el_cdn_de_tailwind(self):
+        """Tailwind Play CDN inyecta <style> en runtime, sin nonce posible."""
+        style_src = self.directives["style-src"]
+        self.assertIn("'unsafe-inline'", style_src)
+        self.assertIn("https://cdn.jsdelivr.net", style_src)  # daisyui@4.10.1
+        self.assertIn("https://cdnjs.cloudflare.com", style_src)  # font-awesome@6.4.0
+
+    def test_img_src_cubre_data_uri_gcs_y_github(self):
+        img_src = self.directives["img-src"]
+        # canvas.toDataURL('image/png') de la firma de asistencia
+        self.assertIn("data:", img_src)
+        # media del bucket sd-lms-media (publicRead, sin querystring auth)
+        self.assertIn("https://storage.googleapis.com", img_src)
+        # portal publico de tickets, montado sobre issues de GitHub
+        self.assertIn("https://*.githubusercontent.com", img_src)
+
+    def test_media_src_cubre_los_videos_de_leccion_en_gcs(self):
+        self.assertIn("https://storage.googleapis.com", self.directives["media-src"])
+
+    def test_object_src_no_es_none_porque_hay_visor_pdf(self):
+        """lesson_view.html usa <object type="application/pdf"> del mismo origen."""
+        self.assertEqual(self.directives["object-src"], ["'self'"])
+
+    def test_frame_src_cubre_video_externo_y_certificado_en_gcs(self):
+        frame_src = self.directives["frame-src"]
+        self.assertIn("https://www.youtube.com", frame_src)
+        self.assertIn("https://www.youtube-nocookie.com", frame_src)
+        self.assertIn("https://player.vimeo.com", frame_src)
+        # certificate_detail.html embebe el PDF del certificado servido por GCS
+        self.assertIn("https://storage.googleapis.com", frame_src)
+
+    def test_clickjacking_coherente_con_x_frame_options(self):
+        self.assertEqual(self.directives["frame-ancestors"], ["'none'"])
+
+
+class ProductionSettingsMigradoTests(SimpleTestCase):
+    """production.py tambien quedo migrado (no se despliega, pero no debe mentir).
+
+    Se valida por fuente: importarlo tiene efectos colaterales (muta
+    INSTALLED_APPS in-place, ver docstring del modulo).
+    """
+
+    def test_production_no_conserva_asignaciones_csp_planas(self):
+        ruta = Path(settings.BASE_DIR) / "config" / "settings" / "production.py"
+        fuente = ruta.read_text(encoding="utf-8")
+        legacy = [
+            name
+            for name in OUTDATED_SETTINGS + ["CSP_INCLUDE_NONCE_IN"]
+            if re.search(rf"^{name}\s*=", fuente, flags=re.MULTILINE)
+        ]
+        self.assertEqual(
+            legacy,
+            [],
+            f"config/settings/production.py todavia asigna settings CSP legacy: {legacy}",
+        )
+
+    def test_production_usa_la_politica_compartida(self):
+        ruta = Path(settings.BASE_DIR) / "config" / "settings" / "production.py"
+        fuente = ruta.read_text(encoding="utf-8")
+        self.assertIn("from .csp import CSP_DIRECTIVES", fuente)

--- a/apps/courses/tasks.py
+++ b/apps/courses/tasks.py
@@ -583,18 +583,31 @@ def check_enrollment_deadlines():
 
 
 def _send_deadline_notification(user, title, message, priority="normal"):
-    """Helper to create in-app notification for deadline alerts."""
-    try:
-        from apps.notifications.models import Notification
+    """
+    Helper to create in-app notification for deadline alerts.
 
-        Notification.objects.create(
+    Delega en NotificationService (la API que usa el resto del codigo) en vez de
+    construir el modelo a mano: el modelo expone `subject`/`body`, no
+    `title`/`message`, y construirlo directo hace que cualquier desalineacion de
+    nombres solo explote en runtime. Ver SD#75.
+    """
+    try:
+        from apps.notifications.models import NotificationTemplate
+        from apps.notifications.services import NotificationService
+
+        notification = NotificationService.create_notification(
             user=user,
-            title=title,
-            message=message,
-            channel="in_app",
+            subject=title,
+            body=message,
+            channel=NotificationTemplate.Channel.IN_APP,
             priority=priority,
-            status="delivered",
-            delivered_at=timezone.now(),
         )
+        # Las alertas de vencimiento son in-app puras: quedan disponibles al
+        # usuario apenas se crean, sin pasar por un canal externo.
+        NotificationService.mark_as_delivered(notification)
+        return notification
     except Exception as e:
-        logger.warning(f"Failed to create notification for {user}: {e}")
+        # NO degradar a warning sin traza: un `except` que descarta el stack
+        # convirtio el typo de SD#75 en un fallo invisible durante meses.
+        logger.exception(f"Error inesperado creando notificacion de vencimiento para {user}: {e}")
+        return None

--- a/apps/courses/tests/test_issue_75.py
+++ b/apps/courses/tests/test_issue_75.py
@@ -1,0 +1,201 @@
+"""
+Tests for SD#75 — las notificaciones de vencimiento nunca se creaban.
+
+Causa raiz
+----------
+`_send_deadline_notification` (apps/courses/tasks.py) construia el modelo a
+mano con `Notification.objects.create(title=..., message=...)`, pero
+`apps.notifications.models.Notification` define `subject`/`body`. Django lanza
+`TypeError` ante kwargs desconocidos, asi que **toda** llamada fallaba... y el
+`except Exception` que la envolvia la degradaba a `logger.warning` sin traza.
+Resultado: cero notificaciones creadas y cero senal en los logs. Meses.
+
+`check_enrollment_deadlines` corre a diario y notifica en 3 momentos
+(vencido -> usuario + cada admin; por vencer en 3 dias; por vencer en 1 dia):
+las 3 rutas pasan por el mismo helper, o sea que las 3 estaban rotas.
+
+Que cubren estos tests
+----------------------
+El test que NO habria atrapado el bug es "la funcion no lanza excepcion" —
+justamente lo que el `except` garantizaba. Aca se afirma que la fila
+**existe en BD** y con los campos correctos:
+
+  - test_helper_persiste_notificacion_con_campos_del_modelo
+  - test_modelo_no_acepta_title_message  (regresion literal del typo)
+  - test_task_notifica_al_usuario_y_al_admin_por_curso_vencido
+  - test_task_notifica_por_curso_proximo_a_vencer  (3 dias y 1 dia)
+  - test_fallo_se_loguea_a_error_con_stack  (el except ya no oculta nada)
+"""
+
+import logging
+from datetime import timedelta
+
+from django.utils import timezone
+
+import pytest
+
+from apps.courses.models import Enrollment
+from apps.courses.tasks import _send_deadline_notification, check_enrollment_deadlines
+from apps.courses.tests.factories import (
+    AdminUserFactory,
+    EnrollmentFactory,
+    PublishedCourseFactory,
+    UserFactory,
+)
+from apps.notifications.models import Notification, NotificationTemplate
+
+
+@pytest.mark.django_db
+class TestSendDeadlineNotificationHelper:
+    """El helper debe DEJAR LA FILA en la tabla, no solo no explotar."""
+
+    def test_helper_persiste_notificacion_con_campos_del_modelo(self):
+        user = UserFactory()
+
+        result = _send_deadline_notification(
+            user=user,
+            title="Curso vencido",
+            message="Tu curso 'Trabajo en Alturas' ha vencido.",
+            priority="high",
+        )
+
+        # Lo que el bug impedia: que exista la fila.
+        assert Notification.objects.filter(user=user).count() == 1
+
+        notification = Notification.objects.get(user=user)
+        assert result is not None
+        assert result.pk == notification.pk
+
+        # Los nombres reales del modelo (subject/body), no title/message.
+        assert notification.subject == "Curso vencido"
+        assert notification.body == "Tu curso 'Trabajo en Alturas' ha vencido."
+        assert notification.channel == NotificationTemplate.Channel.IN_APP
+        assert notification.priority == Notification.Priority.HIGH
+        assert notification.status == Notification.Status.DELIVERED
+        assert notification.delivered_at is not None
+
+    def test_modelo_no_acepta_title_message(self):
+        """Regresion literal: el typo original era un TypeError duro."""
+        user = UserFactory()
+
+        with pytest.raises(TypeError):
+            Notification.objects.create(
+                user=user,
+                title="Curso vencido",
+                message="Tu curso ha vencido.",
+                channel="in_app",
+            )
+
+        assert not Notification.objects.filter(user=user).exists()
+
+    def test_fallo_se_loguea_a_error_con_stack(self, monkeypatch, caplog):
+        """El `except` ya no puede volver invisible un fallo de creacion."""
+        from apps.notifications.services import NotificationService
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("BD caida")
+
+        monkeypatch.setattr(NotificationService, "create_notification", boom)
+        user = UserFactory()
+
+        with caplog.at_level(logging.ERROR, logger="apps.courses.tasks"):
+            result = _send_deadline_notification(user=user, title="Curso vencido", message="cuerpo")
+
+        assert result is None
+        assert not Notification.objects.filter(user=user).exists()
+
+        records = [r for r in caplog.records if r.name == "apps.courses.tasks"]
+        assert records, "el fallo debe quedar en el log, no descartarse en silencio"
+        record = records[-1]
+        assert record.levelno == logging.ERROR
+        assert record.exc_info is not None, "debe conservar el stack trace"
+        assert "BD caida" in caplog.text
+
+
+@pytest.mark.django_db
+class TestCheckEnrollmentDeadlinesCreaNotificaciones:
+    """La task diaria completa: la matricula cambia de estado Y avisa."""
+
+    def _setup(self, due_date, status=Enrollment.Status.ENROLLED):
+        # Usuarios ANTES del curso: el signal de auto-matricula por perfil solo
+        # dispara al guardar el usuario, asi que este orden evita matriculas
+        # espurias que ensucien el conteo.
+        user = UserFactory()
+        admin = AdminUserFactory()
+        course = PublishedCourseFactory(title="Trabajo en Alturas")
+        enrollment = EnrollmentFactory(
+            user=user,
+            course=course,
+            assigned_by=admin,
+            due_date=due_date,
+            status=status,
+        )
+        return user, admin, course, enrollment
+
+    def test_task_notifica_al_usuario_y_al_admin_por_curso_vencido(self):
+        ayer = timezone.now().date() - timedelta(days=1)
+        user, admin, course, enrollment = self._setup(ayer)
+
+        check_enrollment_deadlines()
+
+        enrollment.refresh_from_db()
+        assert enrollment.status == Enrollment.Status.EXPIRED
+
+        # Al usuario
+        user_notifications = Notification.objects.filter(user=user)
+        assert user_notifications.count() == 1
+        aviso = user_notifications.get()
+        assert aviso.subject == "Curso vencido"
+        assert "Trabajo en Alturas" in aviso.body
+        assert aviso.priority == Notification.Priority.HIGH
+        assert aviso.status == Notification.Status.DELIVERED
+
+        # Al admin
+        admin_notifications = Notification.objects.filter(user=admin)
+        assert admin_notifications.count() == 1
+        aviso_admin = admin_notifications.get()
+        assert aviso_admin.subject == "Curso vencido - Usuario"
+        assert "Trabajo en Alturas" in aviso_admin.body
+        assert user.document_number in aviso_admin.body
+        assert aviso_admin.priority == Notification.Priority.NORMAL
+
+    @pytest.mark.parametrize(
+        ("dias", "subject_esperado", "priority_esperada"),
+        [
+            (3, "Curso por vencer en 3 días", Notification.Priority.HIGH),
+            (1, "Curso por vencer en 1 día", Notification.Priority.URGENT),
+        ],
+    )
+    def test_task_notifica_por_curso_proximo_a_vencer(
+        self, dias, subject_esperado, priority_esperada
+    ):
+        vence = timezone.now().date() + timedelta(days=dias)
+        user, admin, course, enrollment = self._setup(vence)
+
+        check_enrollment_deadlines()
+
+        enrollment.refresh_from_db()
+        assert enrollment.status == Enrollment.Status.ENROLLED  # aun no vencio
+
+        notifications = Notification.objects.filter(user=user)
+        assert notifications.count() == 1
+        aviso = notifications.get()
+        assert aviso.subject == subject_esperado
+        assert "Trabajo en Alturas" in aviso.body
+        assert vence.strftime("%d/%m/%Y") in aviso.body
+        assert aviso.priority == priority_esperada
+        assert aviso.status == Notification.Status.DELIVERED
+
+        # El aviso de "por vencer" es solo para el usuario, no para admins.
+        assert not Notification.objects.filter(user=admin).exists()
+
+    def test_matricula_completada_no_genera_aviso(self):
+        """Guardarrail: solo ENROLLED/IN_PROGRESS entran al barrido."""
+        ayer = timezone.now().date() - timedelta(days=1)
+        user, _admin, _course, enrollment = self._setup(ayer, status=Enrollment.Status.COMPLETED)
+
+        check_enrollment_deadlines()
+
+        enrollment.refresh_from_db()
+        assert enrollment.status == Enrollment.Status.COMPLETED
+        assert not Notification.objects.filter(user=user).exists()

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -48,6 +48,11 @@ THIRD_PARTY_APPS = [
     "crispy_tailwind",
     "widget_tweaks",
     "django_htmx",
+    # django-csp: la app no tiene modelos ni migraciones; se instala para que
+    # se registren sus system checks (csp/apps.py importa csp.checks). Sin
+    # esto, configurar la CSP con el formato viejo CSP_* no producia NI header
+    # NI aviso -- la tercera capa de silencio de SD#76.
+    "csp",
 ]
 
 LOCAL_APPS = [

--- a/config/settings/cloudrun.py
+++ b/config/settings/cloudrun.py
@@ -5,6 +5,7 @@ Django settings for Google Cloud Run environment.
 from decouple import config
 
 from .base import *  # noqa: F403, F401
+from .csp import CSP_DIRECTIVES
 
 DEBUG = False
 
@@ -27,6 +28,21 @@ SECURE_HSTS_PRELOAD = True
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = "DENY"
+
+# Content Security Policy (SD#76).
+# Este es el settings que REALMENTE corre en produccion: deploy.yml despliega
+# Cloud Run con DJANGO_SETTINGS_MODULE=config.settings.cloudrun. Antes la CSP
+# vivia solo en production.py (que no se usa) y encima en el formato plano
+# CSP_* que django-csp 4.0 ignora -> nunca se emitio header.
+#
+# Arranca en REPORT-ONLY a proposito: emite el header y el navegador reporta
+# violaciones sin bloquear. Para pasar a bloqueante, primero medir los reportes
+# y despues desplegar con CSP_ENFORCE=True (ver config/settings/csp.py).
+CSP_ENFORCE = config("CSP_ENFORCE", default=False, cast=bool)
+if CSP_ENFORCE:
+    CONTENT_SECURITY_POLICY = {"DIRECTIVES": CSP_DIRECTIVES}
+else:
+    CONTENT_SECURITY_POLICY_REPORT_ONLY = {"DIRECTIVES": CSP_DIRECTIVES}
 
 # Storage backends (Django 5.1+ uses STORAGES instead of deprecated
 # DEFAULT_FILE_STORAGE / STATICFILES_STORAGE)

--- a/config/settings/csp.py
+++ b/config/settings/csp.py
@@ -1,0 +1,137 @@
+"""
+Content Security Policy compartida por los settings que corren desplegados.
+
+Contexto (SD#76)
+----------------
+Hasta este cambio la CSP vivía SOLO en ``config/settings/production.py`` y
+estaba escrita con las variables planas ``CSP_DEFAULT_SRC`` / ``CSP_SCRIPT_SRC``
+/ etc. Eso no emitía ningún header en producción por DOS razones encadenadas:
+
+1. Producción NO corre ``config.settings.production``. El workflow
+   ``.github/workflows/deploy.yml`` despliega Cloud Run con
+   ``DJANGO_SETTINGS_MODULE=config.settings.cloudrun`` (y los jobs de migrate /
+   ensure_admin / axes_reset usan el mismo módulo). ``cloudrun.py`` nunca
+   definió nada de CSP.
+2. Aunque se hubiera cargado, la versión instalada de django-csp es la **4.0**
+   (``requirements/base.txt`` pide ``django-csp>=3.8``, sin pin). Desde 4.0 el
+   middleware construye la política leyendo ``CONTENT_SECURITY_POLICY`` /
+   ``CONTENT_SECURITY_POLICY_REPORT_ONLY`` (un dict con clave ``DIRECTIVES``).
+   Las ``CSP_*`` planas quedaron en ``csp.checks.OUTDATED_SETTINGS``: NO
+   alimentan la política, solo disparan el check ``csp.E001``. El resultado es
+   un fallo silencioso — middleware activo, cero header.
+3. Y ese aviso ``csp.E001`` tampoco se veía, porque ``"csp"`` no estaba en
+   ``INSTALLED_APPS`` y los checks se registran desde ``csp/apps.py``. Tres
+   capas de silencio encima del mismo bug. Ya se instaló la app (``base.py``),
+   así que hoy una ``CSP_*`` plana rompe ``manage.py check`` en vez de pasar
+   desapercibida.
+
+Por qué arranca en REPORT-ONLY
+------------------------------
+La política se emite por defecto como ``Content-Security-Policy-Report-Only``
+(ver ``CSP_ENFORCE`` en ``cloudrun.py`` / ``production.py``). El header viaja y
+el navegador reporta violaciones en consola, pero NO bloquea nada. Es
+deliberado: la app tiene deuda real que una CSP bloqueante rompería de formas
+difíciles de diagnosticar (pantallas en blanco, sin error de servidor):
+
+* 29 bloques ``<script>`` inline en templates y solo 10 llevan
+  ``nonce="{{ request.csp_nonce }}"``. Entre los que NO lo llevan está el
+  portal público de tickets (``apps/feedback/templates/feedback/base.html``),
+  los dashboards con ECharts y la captura de firma de asistencia.
+* Alpine.js evalúa ``x-data`` / ``@click`` con ``new Function()`` y el CDN de
+  Tailwind compila CSS en el navegador: ambos exigen ``'unsafe-eval'``.
+* Tailwind Play CDN inyecta ``<style>`` en runtime SIN nonce, y 35 templates
+  usan atributos ``style="..."``: ambos exigen ``'unsafe-inline'`` en estilos.
+
+OJO con los nonces: por spec, si una directiva trae un nonce el navegador
+IGNORA ``'unsafe-inline'`` en esa misma directiva. Por eso acá NO se usa el
+sentinel ``NONCE`` todavía — meterlo hoy invertiría el efecto y rompería los 24
+templates sin nonce. El camino de salida es: (1) medir con report-only,
+(2) ponerle nonce a los inline restantes, (3) recién ahí cambiar
+``'unsafe-inline'`` por ``NONCE`` y encender ``CSP_ENFORCE``.
+
+Orígenes: cada entrada de abajo sale de un ``grep`` sobre templates, no de un
+template genérico. Ver el comentario de cada directiva.
+"""
+
+from csp.constants import NONE, SELF, UNSAFE_EVAL, UNSAFE_INLINE
+
+# --- Orígenes de terceros efectivamente usados por los templates -------------
+# grep -rhoE 'https?://[a-zA-Z0-9._-]+' --include='*.html' templates apps
+# <script> en templates/base/base.html y apps/feedback/templates/feedback/base.html
+CDN_TAILWIND = "https://cdn.tailwindcss.com"
+# alpinejs@3.x.x, echarts@5.5.0, sortablejs@1.15.0 (js) + daisyui@4.10.1 (css)
+CDN_JSDELIVR = "https://cdn.jsdelivr.net"
+# htmx.org@1.9.11 / @1.9.12 + ext/loading-states
+CDN_UNPKG = "https://unpkg.com"
+# font-awesome@6.4.0 (CSS + woff2)
+CDN_CLOUDFLARE = "https://cdnjs.cloudflare.com"
+
+# Media servida por Google Cloud Storage. En Cloud Run el bucket es
+# GS_BUCKET_NAME=sd-lms-media con GS_DEFAULT_ACL=publicRead y
+# GS_QUERYSTRING_AUTH=False, así que las URLs quedan bajo storage.googleapis.com.
+GCS = "https://storage.googleapis.com"
+
+# Imágenes servidas por GitHub. El portal público de tickets
+# (apps/feedback/) es un frente sobre issues de GitHub: services.py publica las
+# URLs de los adjuntos en el issue y el portal renderiza de vuelta el markdown
+# de los comentarios, cuyas imágenes las sirve GitHub desde estos hosts.
+GITHUB_IMG = "https://*.githubusercontent.com"
+GITHUB = "https://github.com"
+
+# Reproductores de video embebidos por URL en las lecciones
+# (templates/courses/lesson_view.html + partials/builder/lesson_form.html).
+YOUTUBE = "https://www.youtube.com"
+YOUTUBE_NOCOOKIE = "https://www.youtube-nocookie.com"
+VIMEO = "https://player.vimeo.com"
+
+DATA_URI = "data:"
+
+
+# --- Política ----------------------------------------------------------------
+# Nota: los valores son listas; django-csp 4.0 las une con espacios por
+# directiva. Ver csp.utils.build_policy.
+CSP_DIRECTIVES: dict[str, list[str]] = {
+    "default-src": [SELF],
+    # script-src: los 3 CDNs con <script src=...> + 'unsafe-eval' (Alpine
+    # compila expresiones con new Function(); el CDN de Tailwind compila CSS en
+    # el navegador) + 'unsafe-inline' por los 29 <script> inline (solo 10 con
+    # nonce). NO agregar NONCE acá hasta que TODOS lleven nonce: el nonce anula
+    # 'unsafe-inline'.
+    "script-src": [
+        SELF,
+        UNSAFE_INLINE,
+        UNSAFE_EVAL,
+        CDN_TAILWIND,
+        CDN_JSDELIVR,
+        CDN_UNPKG,
+    ],
+    # 25 onclick="" + 4 onsubmit="" en templates. Los nonces NO aplican a
+    # atributos: mientras existan, esto tiene que quedar en 'unsafe-inline'.
+    "script-src-attr": [UNSAFE_INLINE],
+    # style-src: daisyui (jsdelivr) + font-awesome (cdnjs). 'unsafe-inline' es
+    # obligatorio porque Tailwind Play CDN inyecta <style> en runtime sin nonce.
+    "style-src": [SELF, UNSAFE_INLINE, CDN_JSDELIVR, CDN_CLOUDFLARE],
+    # 35 templates con atributo style="...".
+    "style-src-attr": [UNSAFE_INLINE],
+    # img-src: 'data:' es obligatorio — la firma de asistencia se dibuja en un
+    # <canvas> y se vuelca con canvas.toDataURL('image/png') a un <img>
+    # (templates/courses/attendance_lesson.html,
+    # templates/preop_talks/partials/attendees_list.html).
+    "img-src": [SELF, DATA_URI, GCS, GITHUB_IMG, GITHUB],
+    "font-src": [SELF, CDN_CLOUDFLARE],
+    # <video><source src="{{ lesson.content_file.url }}"> apunta a GCS.
+    "media-src": [SELF, GCS],
+    # OJO: 'none' rompería el visor de lecciones PDF, que usa
+    # <object data="{% url 'courses:lesson_content_file' %}" type="application/pdf">
+    # (mismo origen) en templates/courses/lesson_view.html.
+    "object-src": [SELF],
+    # iframes: video externo de las lecciones + el PDF del certificado servido
+    # desde GCS (templates/certifications/certificate_detail.html).
+    "frame-src": [SELF, GCS, YOUTUBE, YOUTUBE_NOCOOKIE, VIMEO],
+    # htmx y fetch() solo pegan al mismo origen (no hay fetch a hosts externos).
+    "connect-src": [SELF],
+    # Coherente con X_FRAME_OPTIONS = "DENY" que ya trae cloudrun.py.
+    "frame-ancestors": [NONE],
+    "form-action": [SELF],
+    "base-uri": [SELF],
+}

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -3,6 +3,7 @@ Django settings for production environment.
 """
 
 from .base import *  # noqa: F403, F401
+from .csp import CSP_DIRECTIVES
 
 DEBUG = False
 
@@ -16,18 +17,20 @@ SECURE_HSTS_PRELOAD = True
 SECURE_SSL_REDIRECT = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-# Content Security Policy - Nonce-based (secure, no unsafe-inline)
-CSP_DEFAULT_SRC = ("'self'",)
-CSP_SCRIPT_SRC = ("'self'", "cdn.jsdelivr.net", "cdn.tailwindcss.com", "unpkg.com")
-CSP_STYLE_SRC = ("'self'", "cdn.jsdelivr.net", "fonts.googleapis.com")
-CSP_IMG_SRC = ("'self'", "data:", "storage.googleapis.com", "*.googleusercontent.com")
-CSP_FONT_SRC = ("'self'", "fonts.gstatic.com", "cdn.jsdelivr.net")
-CSP_CONNECT_SRC = ("'self'",)
-CSP_FRAME_ANCESTORS = ("'none'",)
-CSP_FORM_ACTION = ("'self'",)
-
-# Enable nonce for inline scripts and styles
-CSP_INCLUDE_NONCE_IN = ["script-src", "style-src"]
+# Content Security Policy (SD#76).
+# Antes esto eran variables planas CSP_DEFAULT_SRC / CSP_SCRIPT_SRC / ... que
+# django-csp 4.0 (la version instalada) NO lee: quedaron en
+# csp.checks.OUTDATED_SETTINGS, que solo alimenta el check csp.E001. Y como
+# "csp" tampoco estaba en INSTALLED_APPS, ese check ni siquiera se registraba:
+# cero header y cero aviso. Ahora la app esta instalada (ver base.py), asi que
+# reintroducir una CSP_* plana rompe `manage.py check` en vez de ignorarse.
+# La politica real vive en config/settings/csp.py y la comparte cloudrun.py,
+# que es el settings que efectivamente corre en produccion (deploy.yml).
+CSP_ENFORCE = config("CSP_ENFORCE", default=False, cast=bool)  # noqa: F405
+if CSP_ENFORCE:
+    CONTENT_SECURITY_POLICY = {"DIRECTIVES": CSP_DIRECTIVES}
+else:
+    CONTENT_SECURITY_POLICY_REPORT_ONLY = {"DIRECTIVES": CSP_DIRECTIVES}
 
 # Storage backends (Django 5.1+ STORAGES)
 STORAGES = {


### PR DESCRIPTION
## Bundle de bugs de producción — 2 issues

| Issue | Qué |
|---|---|
| **#75** | Las notificaciones de vencimiento nunca se creaban |
| **#76** | No se emitía header CSP en producción |

### #75 — nació roto y nunca funcionó

`_send_deadline_notification` construía `Notification(title=..., message=...)` cuando el modelo define `subject`/`body`. El `try/except` se tragaba el `TypeError` en silencio, así que la tarea reportaba éxito.

Roto desde `d36d9e4` (2026-03-04); el modelo tiene `subject`/`body` desde enero. **Tasa de fallo 100% durante ~147 días.**

**Pérdidas reales: cero — por casualidad.** Ninguna matrícula de producción alcanzó todavía una ventana de vencimiento: el `due_date` más próximo es 2027-01-05, y la primera pérdida real habría sido el **2027-02-27**. El fix llega antes.

Se reemplazó la construcción directa por `NotificationService`, que es la API que ya usa el resto del código y deja los nombres de campo en un solo lugar. El `except` ahora usa `logger.exception` (nivel error + stack), siguiendo el patrón del repo.

**Auditoría del patrón:** se corrió un análisis AST sobre todo `apps/` validando los kwargs de cada `Model.objects.create` y `Model(...)` contra los campos reales. **Un solo hallazgo en todo el repo — este.** (Nota: un `grep "Notification("` no encuentra el bug, porque la llamada es `Notification.objects.create(`.)

**Hallazgo más grave que el typo:** aun con el fix, `check_enrollment_deadlines` **no se ejecutará en producción**. No hay worker ni beat (el `CMD` de la imagen es solo gunicorn), hay 0 `PeriodicTask` registradas, 0 `TaskResult` históricos y ningún job de Cloud Scheduler apunta a `sd-lms`. El portafolio usa "cron Django = Cloud Scheduler → endpoint HTTP"; SD nunca lo cableó. Fuera del alcance de este PR, pero sin eso el feature sigue muerto.

### #76 — había una tercera capa que el issue no mencionaba

Los dos problemas conocidos: la config vivía en `production.py` mientras prod corre `config.settings.cloudrun`, y usaba el formato plano `CSP_*` que django-csp 4.0 ignora (lee `CONTENT_SECURITY_POLICY`, un dict).

**El tercero:** `"csp"` **tampoco estaba en `INSTALLED_APPS`**. Como los checks se registran desde `csp/apps.py`, ni siquiera saltaba el aviso de migración que la versión 4.0 trae para esto. **Cero header y cero warning.** Verificado empíricamente: con la app instalada y el formato viejo, `manage.py check` ahora falla; antes pasaba en verde.

La política vive en `config/settings/csp.py`, compartida por `cloudrun.py` y `production.py`. **Cada directiva sale de evidencia**, no de un template genérico: se relevaron los orígenes reales de los templates (Tailwind Play CDN, Alpine, ECharts, Sortable, htmx, daisyui, font-awesome, GCS, hosts de GitHub, YouTube/Vimeo).

Dos trampas evitadas:
- **`object-src 'self'`, no `'none'`** — el visor de lecciones usa `<object type="application/pdf">`. Con `'none'` se habría roto sin ningún error de servidor.
- **Sin sentinel `NONCE`** — por especificación, un nonce hace que el navegador **ignore** `'unsafe-inline'` en esa misma directiva. Hay 29 bloques `<script>` inline y solo 10 llevan nonce; meterlo habría roto el portal público de tickets, los dashboards con ECharts y la firma de asistencia.

**Va en report-only** (`CSP_ENFORCE=False` por defecto): el header viaja y el navegador reporta violaciones en consola, sin bloquear. Alpine y el CDN de Tailwind exigen `'unsafe-eval'`, Tailwind inyecta `<style>` en runtime sin nonce, y hay 19 inline sin nonce — una CSP bloqueante rompería eso con pantallas a medias y **sin error 500**, indiagnosticable desde los logs. Para pasar a bloqueante: desplegar con `CSP_ENFORCE=True`, un env var, sin cambio de código.

Salvedad: sin `report-uri` los reportes quedan en la consola del navegador, no se recolectan server-side. Agregar el endpoint de colección sería el paso siguiente.

**Detalle relevante:** `config/settings/test.py` saca el `CSPMiddleware` a propósito — por eso la suite nunca podía ver esto. Los tests nuevos lo reinyectan y afirman sobre el **header de la respuesta**, no sobre la existencia de una constante.

### Verificación

```
suite:                  1632 passed, 1 skipped, 142 subtests  (base main: 1605)
makemigrations --check: No changes detected
manage.py check:        sin issues
```

Delta = exactamente los 27 tests nuevos (7 de #75 + 20 de #76). Cero regresiones.

**Ambos lotes de tests fueron validados con control negativo:** los de #75 dan 5 de 7 rojos contra el código pre-fix; los de #76 incluyen uno que fija la causa raíz (`test_el_formato_viejo_csp_plano_NO_emite_header`).

---

Refs #75 #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
