### PR TITLE
fix(pagos): webhook WOMPI crasheaba al resolver properties de la firma

### DIFF
--- a/pagos/tests/test_wompi_webhook_signature.py
+++ b/pagos/tests/test_wompi_webhook_signature.py
@@ -1,0 +1,55 @@
+"""verify_webhook_signature() resolvia las `properties` de la firma (rutas
+tipo "transaction.id", relativas a `data`) contra `data.transaction` ya
+desanidado -- duplicaba el prefijo "transaction" y explotaba con
+"'str' object has no attribute 'get'" en el 2do segmento ante CUALQUIER
+webhook real de WOMPI (bug portfolio-wide, confirmado tambien en SD,
+ya parchado en pagos-template#12 y en FormasFuturo Refs #68, portado aca
+antes de que se materialice como pago perdido).
+"""
+import hashlib
+
+from django.test import TestCase, override_settings
+
+from pagos import wompi
+
+
+@override_settings(WOMPI_EVENTS_KEY='events-secret-real', WOMPI_INTEGRITY_KEY='integrity-secret-checkout')
+class VerifyWebhookSignatureTest(TestCase):
+    def _payload(self, checksum):
+        return {
+            'timestamp': 1700000000,
+            'signature': {
+                'properties': ['transaction.id', 'transaction.status', 'transaction.amount_in_cents'],
+                'checksum': checksum,
+            },
+            'data': {
+                'transaction': {
+                    'id': 'tx-firma-1',
+                    'status': 'APPROVED',
+                    'amount_in_cents': 7500000,
+                }
+            },
+        }
+
+    def _checksum_con(self, key):
+        concat = 'tx-firma-1' + 'APPROVED' + '7500000' + '1700000000' + key
+        return hashlib.sha256(concat.encode()).hexdigest()
+
+    def test_no_crashea_y_firma_real_es_valida(self):
+        """Regresion del bug: antes esto lanzaba AttributeError. Ahora debe
+        resolver bien las properties y validar la firma real (events key)."""
+        checksum_real = self._checksum_con('events-secret-real')
+        payload = self._payload(checksum_real)
+
+        self.assertTrue(wompi.verify_webhook_signature(payload, checksum_real))
+
+    def test_firma_con_integrity_key_es_invalida(self):
+        checksum_con_integrity = self._checksum_con('integrity-secret-checkout')
+        payload = self._payload(checksum_con_integrity)
+
+        self.assertFalse(wompi.verify_webhook_signature(payload, checksum_con_integrity))
+
+    def test_checksum_incorrecto_es_invalido(self):
+        payload = self._payload('checksum-cualquiera-invalido')
+
+        self.assertFalse(wompi.verify_webhook_signature(payload, 'checksum-cualquiera-invalido'))

--- a/pagos/wompi.py
+++ b/pagos/wompi.py
@@ -36,13 +36,19 @@ def verify_webhook_signature(event_data, received_signature):
     try:
         properties = event_data.get('signature', {}).get('properties', [])
         timestamp = event_data.get('timestamp')
-        tx = event_data.get('data', {}).get('transaction', {})
+        # Las `properties` de WOMPI son rutas con punto relativas a `data`
+        # (p.ej. "transaction.id", "transaction.status"), por eso se
+        # resuelven desde `data` -- NO desde `data.transaction` ya
+        # desanidado, que duplicaba el prefijo "transaction" y explotaba
+        # con "'str' object has no attribute 'get'" en el 2do segmento
+        # (bug portfolio-wide, ya parchado en pagos-template#12 y en
+        # FormasFuturo Refs #68).
+        data = event_data.get('data', {})
 
         values = []
         for prop in properties:
-            keys = prop.split('.')
-            val = tx
-            for k in keys:
+            val = data
+            for k in prop.split('.'):
                 val = val.get(k, '') if isinstance(val, dict) else ''
             values.append(str(val))
 


### PR DESCRIPTION
## Resumen

- `verify_webhook_signature()` resolvia las `properties` de la firma (rutas tipo `transaction.id`, relativas a `data`) contra `data.transaction` ya desanidado -- duplicaba el prefijo `transaction` y explotaba con `AttributeError: 'str' object has no attribute 'get'` en el 2do segmento ante CUALQUIER webhook real de WOMPI.
- Bug portfolio-wide confirmado en NOVAPCR/PlasticosAmbientales/SD, ya parchado independientemente en FormasFuturo (Refs #68) y en la fuente canonica `pagos-template` (Indunnova16/pagos-template#12). Se porta el mismo fix, tal cual, a SD.
- En SD el modulo de pagos es nuevo (Sprint B cerro hace ~1 semana) y aun no ha recibido trafico real de webhook (0 en 60 dias), pero el precio real del plan esta por activarse -- esto era una bomba de tiempo apenas WOMPI llame por primera vez.

## Fix

En `pagos/wompi.py`, las `properties` ahora se resuelven desde `data` (no desde `data.transaction` ya desanidado).

## Test plan

- [x] Test de regresion nuevo `pagos/tests/test_wompi_webhook_signature.py` con payload realista (`properties=["transaction.id","transaction.status","transaction.amount_in_cents"]`, `data.transaction={id,status,amount_in_cents}`): confirma que ya no crashea y que la firma con `WOMPI_EVENTS_KEY` valida correctamente (e invalida con `WOMPI_INTEGRITY_KEY`).
- [x] Suite completa de `pagos` corrida localmente: 81/81 tests OK.
- [ ] Deploy + smoke prod (webhook POST firmado, `status=PENDING`, cleanup del registro de prueba).

Refs #68 (FormasFuturo), Indunnova16/pagos-template#12