### PR TITLE
Conciliación diaria de pagos contra la API de WOMPI (port pagos-template#13)

### DIFF
--- a/pagos/conciliacion.py
+++ b/pagos/conciliacion.py
@@ -1,0 +1,58 @@
+"""Conciliación contra la API de WOMPI — la fuente de verdad del dinero.
+
+Origen (incidente Obraje 2026-07/08): el webhook y el redirect del navegador
+pueden fallar AMBOS (bug de firma, bug de parseo, ruta faltante en el
+wompi-router, cliente que cierra la pestaña...). Cuando eso pasa, WOMPI
+cobra pero el sistema no registra nada — y nadie se entera hasta que el
+cliente reclama. Esta conciliación cierra esa clase entera de problema:
+consulta las transacciones reales del merchant y detecta cualquier APPROVED
+de ESTA app (por prefijo de referencia) que no tenga su Pago local.
+
+Se invoca desde el comando `conciliar_pagos_wompi` (manual / --crear) y
+desde el endpoint `cron/conciliar-wompi/` (Cloud Scheduler diario,
+solo-detección). Cada faltante se loguea como ERROR con el marcador
+`CONCILIACION_WOMPI` — la alerta de Cloud Logging se engancha a ese texto.
+"""
+import logging
+from datetime import timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+from . import wompi
+from .models import Pago
+
+logger = logging.getLogger(__name__)
+
+
+def detectar_faltantes(dias=7):
+    """Transacciones APPROVED de esta app en WOMPI sin Pago local.
+
+    Retorna la lista de transacciones (dicts crudos de la API) faltantes.
+    Loguea un ERROR con marcador CONCILIACION_WOMPI por cada una.
+    """
+    prefix = getattr(settings, 'WOMPI_REFERENCE_PREFIX', 'APP') + '-'
+    hasta = timezone.now()
+    desde = hasta - timedelta(days=dias)
+    txs = wompi.listar_transacciones(
+        desde.strftime('%Y-%m-%dT%H:%M:%S'),
+        hasta.strftime('%Y-%m-%dT%H:%M:%S'),
+    )
+
+    faltantes = []
+    for tx in txs:
+        ref = tx.get('reference') or ''
+        if not ref.startswith(prefix):
+            continue  # transaccion de OTRA app del portafolio (merchant compartido)
+        if tx.get('status') != 'APPROVED':
+            continue
+        if Pago.objects.filter(wompi_transaction_id=tx.get('id', '')).exists():
+            continue
+        faltantes.append(tx)
+        logger.error(
+            'CONCILIACION_WOMPI: transaccion APROBADA sin registro local '
+            'tx=%s ref=%s monto_cents=%s finalizada=%s',
+            tx.get('id'), ref, tx.get('amount_in_cents'),
+            tx.get('finalized_at') or tx.get('created_at'),
+        )
+    return faltantes

--- a/pagos/management/commands/conciliar_pagos_wompi.py
+++ b/pagos/management/commands/conciliar_pagos_wompi.py
@@ -1,0 +1,121 @@
+"""Concilia los pagos locales contra la API de WOMPI (fuente de verdad).
+
+Detecta transacciones APPROVED del merchant que pertenecen a ESTA app
+(prefijo WOMPI_REFERENCE_PREFIX) y no tienen Pago local — el escenario que
+dejó un pago real de Obraje cobrado-pero-invisible en jul-2026 (webhook
+roto + redirect no completado).
+
+    python manage.py conciliar_pagos_wompi                # solo detecta y reporta
+    python manage.py conciliar_pagos_wompi --dias 30      # ventana mas amplia
+    python manage.py conciliar_pagos_wompi --crear        # ademas registra cada
+                                                          # faltante (idempotente,
+                                                          # misma logica del webhook:
+                                                          # Pago + activar suscripcion
+                                                          # + avanzar fecha + factura)
+
+El default es SOLO-DETECCION a proposito: registrar un pago mueve dinero
+(factura DIAN vía Alegra, avance de fecha) — la alerta avisa y un humano
+decide correr --crear tras confirmar contra el dashboard de WOMPI.
+"""
+from django.core.management.base import BaseCommand
+
+from pagos import alegra
+from pagos.conciliacion import detectar_faltantes
+from pagos.models import Pago, Suscripcion, calcular_n_meses
+from pagos.views import _avanzar_fecha_proximo_pago
+
+ESTADO_MAP = {
+    'APPROVED': 'APROBADO',
+    'DECLINED': 'RECHAZADO',
+    'ERROR': 'ERROR',
+    'PENDING': 'PENDIENTE',
+    'VOIDED': 'RECHAZADO',
+}
+
+
+class Command(BaseCommand):
+    help = 'Detecta (y opcionalmente registra) pagos WOMPI aprobados sin registro local.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--dias', type=int, default=7,
+                            help='Ventana hacia atrás a conciliar (default 7)')
+        parser.add_argument('--crear', action='store_true',
+                            help='Registra cada faltante (Pago + suscripcion + factura)')
+
+    def handle(self, *args, **options):
+        faltantes = detectar_faltantes(dias=options['dias'])
+
+        if not faltantes:
+            self.stdout.write(self.style.SUCCESS(
+                f'Conciliación OK: sin pagos faltantes en los últimos {options["dias"]} días.'
+            ))
+            return
+
+        self.stdout.write(self.style.ERROR(
+            f'{len(faltantes)} transacción(es) APROBADA(s) en WOMPI sin registro local:'
+        ))
+        for tx in faltantes:
+            self.stdout.write(
+                f'  tx={tx.get("id")} ref={tx.get("reference")} '
+                f'monto=${tx.get("amount_in_cents", 0) / 100:,.0f} '
+                f'finalizada={tx.get("finalized_at") or tx.get("created_at")}'
+            )
+
+        if not options['crear']:
+            self.stdout.write(self.style.WARNING(
+                'Solo detección (default). Para registrarlas: --crear '
+                '(confirmá antes contra el dashboard de WOMPI).'
+            ))
+            return
+
+        for tx in faltantes:
+            self._registrar(tx)
+
+    def _registrar(self, tx):
+        """Misma lógica idempotente del webhook para un APPROVED recuperado."""
+        tx_id = tx.get('id')
+        monto = tx.get('amount_in_cents', 0) / 100
+        suscripcion = Suscripcion.objects.select_related('plan').first()
+        n_meses = (
+            calcular_n_meses(monto, suscripcion.plan.precio)
+            if suscripcion and suscripcion.plan else 1
+        )
+        pago, created = Pago.objects.get_or_create(
+            wompi_transaction_id=tx_id,
+            defaults={
+                'suscripcion': suscripcion,
+                'monto': monto,
+                'n_meses': n_meses,
+                'estado': 'PENDIENTE',
+                'wompi_reference': tx.get('reference', ''),
+            },
+        )
+        ya_estaba_aprobado = (not created) and (pago.estado == 'APROBADO')
+        pago.estado = ESTADO_MAP.get(tx.get('status'), 'PENDIENTE')
+        pago.detalle_respuesta = tx
+        pago.save()
+        self.stdout.write(self.style.SUCCESS(
+            f'  Pago {"creado" if created else "actualizado"} id={pago.id} estado={pago.estado}'
+        ))
+
+        if ya_estaba_aprobado:
+            return
+        if pago.suscripcion:
+            _avanzar_fecha_proximo_pago(pago)
+            self.stdout.write(
+                f'  Suscripción ACTIVA, próximo pago = {pago.suscripcion.fecha_proximo_pago}'
+            )
+        if not pago.alegra_invoice_id:
+            try:
+                factura = alegra.generar_factura_desde_pago(pago)
+            except Exception as e:
+                factura = None
+                self.stdout.write(self.style.ERROR(f'  Error generando factura Alegra: {e}'))
+            if factura:
+                self.stdout.write(self.style.SUCCESS(
+                    f'  Factura Alegra {pago.alegra_invoice_id} emitida.'
+                ))
+            else:
+                self.stdout.write(self.style.ERROR(
+                    '  No se generó factura Alegra (revisar logs / datos de facturación).'
+                ))

--- a/pagos/tests/test_conciliacion.py
+++ b/pagos/tests/test_conciliacion.py
@@ -1,0 +1,94 @@
+"""Conciliación contra la API de WOMPI (origen: incidente Obraje jul-2026,
+pago cobrado por WOMPI sin registro local por webhook roto + redirect no
+completado). Cubre: detección por prefijo, exclusión de pagos ya
+registrados, exclusión de otras apps del merchant compartido, y el endpoint
+cron de solo-detección.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from pagos.conciliacion import detectar_faltantes
+from pagos.models import Pago, PlanServicio, Suscripcion
+
+
+def _tx(tx_id, ref, status='APPROVED', cents=7500000):
+    return {
+        'id': tx_id, 'reference': ref, 'status': status,
+        'amount_in_cents': cents, 'created_at': '2026-08-01T12:00:00.000Z',
+        'finalized_at': '2026-08-01T12:01:00.000Z',
+    }
+
+
+@override_settings(WOMPI_REFERENCE_PREFIX='MIAPP')
+class DetectarFaltantesTest(TestCase):
+    def setUp(self):
+        self.plan = PlanServicio.objects.create(nombre='Plan', precio=75000)
+        self.suscripcion = Suscripcion.objects.create(plan=self.plan)
+
+    @patch('pagos.conciliacion.wompi.listar_transacciones')
+    def test_detecta_aprobada_sin_registro_local(self, mock_list):
+        mock_list.return_value = [_tx('tx-perdida', 'MIAPP-1-1-202608-1M')]
+
+        faltantes = detectar_faltantes(dias=7)
+
+        self.assertEqual([t['id'] for t in faltantes], ['tx-perdida'])
+
+    @patch('pagos.conciliacion.wompi.listar_transacciones')
+    def test_ignora_pago_ya_registrado(self, mock_list):
+        Pago.objects.create(
+            suscripcion=self.suscripcion, monto=75000,
+            estado='APROBADO', wompi_transaction_id='tx-registrada',
+        )
+        mock_list.return_value = [_tx('tx-registrada', 'MIAPP-1-1-202608-1M')]
+
+        self.assertEqual(detectar_faltantes(dias=7), [])
+
+    @patch('pagos.conciliacion.wompi.listar_transacciones')
+    def test_ignora_otras_apps_del_merchant_compartido(self, mock_list):
+        # El merchant WOMPI es compartido: la API devuelve transacciones de
+        # TODO el portafolio (OBRAJE-, NOVAPCR-, DI-...). Solo las del
+        # prefijo propio cuentan.
+        mock_list.return_value = [
+            _tx('tx-obraje', 'OBRAJE-x-y-202608-1M'),
+            _tx('tx-di', 'DI-1-1-202608-1M'),
+        ]
+
+        self.assertEqual(detectar_faltantes(dias=7), [])
+
+    @patch('pagos.conciliacion.wompi.listar_transacciones')
+    def test_ignora_no_aprobadas(self, mock_list):
+        mock_list.return_value = [
+            _tx('tx-declinada', 'MIAPP-1-1-202608-1M', status='DECLINED'),
+            _tx('tx-pendiente', 'MIAPP-1-1-202608-1M', status='PENDING'),
+        ]
+
+        self.assertEqual(detectar_faltantes(dias=7), [])
+
+
+@override_settings(WOMPI_REFERENCE_PREFIX='MIAPP')
+class CronConciliarWompiTest(TestCase):
+    @patch('pagos.conciliacion.wompi.listar_transacciones')
+    def test_post_reporta_faltantes_sin_registrar(self, mock_list):
+        mock_list.return_value = [_tx('tx-perdida', 'MIAPP-1-1-202608-1M')]
+
+        resp = self.client.post(reverse('pagos:cron_conciliar_wompi'))
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertTrue(body['success'])
+        self.assertEqual(body['faltantes'], 1)
+        self.assertEqual(body['tx_ids'], ['tx-perdida'])
+        # Solo-detección: NUNCA crea el Pago (eso es decisión humana --crear).
+        self.assertFalse(Pago.objects.filter(wompi_transaction_id='tx-perdida').exists())
+
+    def test_get_no_permitido(self):
+        resp = self.client.get(reverse('pagos:cron_conciliar_wompi'))
+        self.assertEqual(resp.status_code, 405)
+
+    @patch('pagos.conciliacion.wompi.listar_transacciones', side_effect=Exception('API caida'))
+    def test_error_de_api_responde_500_y_loguea(self, mock_list):
+        resp = self.client.post(reverse('pagos:cron_conciliar_wompi'))
+        self.assertEqual(resp.status_code, 500)
+        self.assertFalse(resp.json()['success'])

--- a/pagos/urls.py
+++ b/pagos/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('facturacion/', views.DatosFacturacionView.as_view(), name='facturacion'),
     path('historial/', views.HistorialPagosView.as_view(), name='historial'),
     path('webhook/', views.WompiWebhookView.as_view(), name='webhook'),
+    path('cron/conciliar-wompi/', views.cron_conciliar_wompi, name='cron_conciliar_wompi'),
 ]

--- a/pagos/views.py
+++ b/pagos/views.py
@@ -349,3 +349,27 @@ class WompiWebhookView(View):
         except Exception as e:
             logger.error(f'WOMPI webhook error: {e}')
             return JsonResponse({'status': 'error'}, status=400)
+
+
+@csrf_exempt
+def cron_conciliar_wompi(request):
+    """Endpoint para Cloud Scheduler — conciliación diaria contra WOMPI.
+
+    URL: /pagos/cron/conciliar-wompi/   Método: POST
+    Solo DETECTA (nunca registra): cada faltante queda logueado como ERROR
+    con marcador CONCILIACION_WOMPI (dispara la alerta de Cloud Logging).
+    Registrar es decisión humana via `manage.py conciliar_pagos_wompi --crear`.
+    """
+    if request.method != 'POST':
+        return JsonResponse({'error': 'Método no permitido. Use POST.'}, status=405)
+    from .conciliacion import detectar_faltantes
+    try:
+        faltantes = detectar_faltantes(dias=7)
+    except Exception as e:
+        logger.exception('CONCILIACION_WOMPI: fallo consultando la API de WOMPI')
+        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+    return JsonResponse({
+        'success': True,
+        'faltantes': len(faltantes),
+        'tx_ids': [t.get('id') for t in faltantes],
+    })

--- a/pagos/wompi.py
+++ b/pagos/wompi.py
@@ -60,3 +60,36 @@ def verify_webhook_signature(event_data, received_signature):
         return hmac.compare_digest(computed, received_signature)
     except Exception:
         return False
+
+
+def listar_transacciones(from_date, until_date, page_size=200):
+    """Lista transacciones del merchant entre 2 fechas (paginado completo).
+
+    OJO: el merchant de WOMPI es COMPARTIDO por todo el portafolio Indunnova
+    (una sola cuenta, un solo wompi-router) -- esto devuelve transacciones de
+    TODAS las apps. Filtrar por prefijo de referencia (WOMPI_REFERENCE_PREFIX)
+    antes de usar. Formato de fecha: 'YYYY-MM-DDTHH:MM:SS'.
+    """
+    txs = []
+    page = 1
+    while True:
+        resp = requests.get(
+            f"{get_base_url()}/transactions",
+            headers=get_headers(),
+            params={
+                'from_date': from_date,
+                'until_date': until_date,
+                'page_size': page_size,
+                'page': page,
+            },
+            timeout=20,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        data = payload.get('data', [])
+        txs.extend(data)
+        total = payload.get('meta', {}).get('total_results', len(txs))
+        if len(data) < page_size or len(txs) >= total:
+            break
+        page += 1
+    return txs


### PR DESCRIPTION
Port de la conciliación canónica (`Indunnova16/pagos-template` PR #13) al módulo `pagos/` de SD, ANTES del primer pago real (Sprint B recién cerrado, precio placeholder).

## Qué hace
Consulta la API de WOMPI (merchant compartido del portafolio) y detecta cualquier transacción APPROVED con referencia `SD-...` que no tenga `Pago` local — la clase de incidente Obraje jul-2026 (webhook + redirect fallan a la vez, WOMPI cobra, el sistema no registra).

## Cambios
- `pagos/wompi.py`: `listar_transacciones()` (paginado completo). `verify_webhook_signature` intacto (fix de PR #125 preservado).
- `pagos/conciliacion.py`: `detectar_faltantes()` — filtro `prefix + '-'` (`SD-`, no matchea `SDCHECKLIST-`), log ERROR con marcador `CONCILIACION_WOMPI`.
- `pagos/management/commands/conciliar_pagos_wompi.py`: default solo-detección; `--crear` (decisión humana) replica la lógica idempotente del webhook local de SD (`calcular_n_meses`, `_avanzar_fecha_proximo_pago`, factura Alegra con try/except).
- `pagos/views.py` + `pagos/urls.py`: `cron_conciliar_wompi` → `POST /pagos/cron/conciliar-wompi/` (Cloud Scheduler diario, solo-detección).
- `pagos/tests/test_conciliacion.py`: 7 tests (detección, ya-registrado, otras apps del merchant compartido, no-aprobadas, cron 200/405/500).

## Verificación de prefijo
`WOMPI_REFERENCE_PREFIX` default `"SD"` en `config/settings/base.py`; las referencias locales se generan `f"{prefix}-{suscripcion.id}-{plan.id}-..."` → consistente con la clave `SD` del wompi-router. Sin inconsistencias.

## Tests
`pytest pagos/tests/ --no-cov` → **88 passed** (suite completa de pagos, settings `config.settings.test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)