### PR TITLE
chore(ci): correr workflows en runners GCP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   deploy:
     name: Build and Deploy
-    runs-on: ubuntu-latest
+    runs-on: [gcp, linux-amd64]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Motivo

Directiva: **todos los repos del portafolio deben correr en los runners self-hosted de GCP (la VM)**, no en runners GitHub-hosted.

En la org `Indunnova16` los únicos runners registrados y online son `gcp-worker-1/2/3` (labels `gcp,linux-amd64`, **Debian 12 x86_64**). No queda ningún runner macOS. `[gcp, linux-amd64]` es el valor canónico que ya usan Colorplastic, Piloto, SD, SDCheckList y NovaIAsistente.

## Archivos cambiados

- `.github/workflows/deploy.yml`

## Adaptación de entorno

**Ninguna.** El workflow no usa `actions/setup-python`, ni comandos de macOS (`brew`, `sed -i ''`, `sips`), ni rutas `/Users/...` o `/Volumes/...`, ni `services:` de docker. Lo que necesita ya está en los gcp-workers: `gcloud` (SDK 577.0.0), `docker` (29.7.1) y `sudo` sin password.

Los `--command "python"` que aparecen en el YAML son argumentos de Cloud Run Jobs: corren dentro del contenedor, no en el runner.

## Alcance

Sólo se tocó `.github/workflows/`. No se modificó ningún step, condición ni secret más allá de lo que exige correr en un Linux self-hosted.